### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A server implementing the [Model Context Protocol](https://modelcontextprotocol.
 
 This package allows MCP clients to perform Pulumi operations like retrieving package information, previewing changes, deploying updates, and retrieving stack outputs programmatically without needing the Pulumi CLI installed directly in the client environment.
 
+<a href="https://glama.ai/mcp/servers/@pulumi/mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pulumi/mcp-server/badge" alt="@pulumi/mcp-server MCP server" />
+</a>
+
 ## Usage
 
 The Pulumi CLI has to be installed on you machine.


### PR DESCRIPTION
This PR adds a badge for the [@pulumi/mcp-server](https://glama.ai/mcp/servers/@pulumi/mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pulumi/mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pulumi/mcp-server/badge" alt="@pulumi/mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.