### PR TITLE
feat: add glama.ia support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Pulumi MCP Server
 
+<a href="https://glama.ai/mcp/servers/@pulumi/mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pulumi/mcp-server/badge" />
+</a>
+
 > **Note:** This MCP server is currently under active development. Its API (including available commands and their arguments) is experimental and may introduce breaking changes without notice. Please file an issue on [GitHub](https://github.com/pulumi/mcp-server/issues) if you encounter bugs or need support for additional Pulumi commands.
 
 A server implementing the [Model Context Protocol](https://modelcontextprotocol.io) (MCP) for interacting with Pulumi CLI using the Pulumi Automation API and Pulumi Cloud API.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "dirien",
+    "mikhailshilkov"
+  ]
+}


### PR DESCRIPTION
releates to #13 

- Adds glama.ai badge to `README.md` and claims the MCP server entry via `glama.json`
![image](https://glama.ai/mcp/servers/@pulumi/mcp-server/badge)