### PR TITLE
Tidy up the Deploy to AWS tool and prompt interface

### DIFF
--- a/src/deploy/deploy.ts
+++ b/src/deploy/deploy.ts
@@ -107,8 +107,7 @@ export const deployCommands = {
 export const deployPrompts = {
   'deploy-to-aws': {
     name: 'deploy-to-aws',
-    description:
-      'AWS deployment guidance prompt. Used to generate Pulumi infrastructure code for deploying applications to AWS.',
+    description: 'Deploy application code to AWS by generating Pulumi infrastructure',
     handler: () => promptHandler('deploy-to-aws')
   }
 };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -79,9 +79,9 @@ export class Server extends McpServer {
     Object.entries(deployCommands).forEach(([commandName, command]) => {
       const toolName = commandName;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      this.tool(toolName, command.description, command.schema, async (args: any) => {
+      this.tool(toolName, command.description, command.schema, async () => {
         try {
-          return await command.handler(args);
+          return await command.handler();
         } catch (error) {
           return handleError(error, toolName);
         }
@@ -90,7 +90,7 @@ export class Server extends McpServer {
 
     // Register deploy prompts
     Object.entries(deployPrompts).forEach(([promptName, prompt]) => {
-      this.prompt(promptName, {}, async () => {
+      this.prompt(promptName, prompt.description, {}, async () => {
         try {
           return await prompt.handler();
         } catch (error) {


### PR DESCRIPTION
Three tiny changes to Deploy to AWS:

1. Fix the typing error where `args` are passed to `command.handler` that has no arguments (why doesn't this fail the build?)
2. Pass the prompt description to the MCP SDK.
3. Reduce the prompt description to fit on one line (took it from the tool). Result:

<img width="1338" alt="image" src="https://github.com/user-attachments/assets/9c53a6e9-3585-4d14-8cb9-e62dad508b46" />
