### PR TITLE
A prompt to convert Terraform to Pulumi TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "tsx watch src/index.ts stdio",
     "build": "tsup",
     "build:watch": "tsup --watch",
-    "test": "NODE_OPTIONS='--loader ts-node/esm' mocha 'test/**/*.test.ts'",
+    "test": "NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 'test/**/*.test.ts'",
     "test:watch": "NODE_OPTIONS='--loader ts-node/esm' mocha --watch --watch-files test 'test/**/*.test.ts'",
     "inspector": " npx @modelcontextprotocol/inspector dist/index.js"
   },

--- a/src/deploy/deploy.ts
+++ b/src/deploy/deploy.ts
@@ -1,28 +1,5 @@
 import { logger } from '../logging/logging.js';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-// Get the directory of the current module
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Function to read prompt from local markdown file
-async function getPrompt(promptName: string, type: string): Promise<string> {
-  // Construct path to the markdown file in same directory as the bundled JS
-  const promptPath = path.join(__dirname, `${promptName}.md`);
-
-  logger.info(`Reading prompt from: ${promptPath}`);
-
-  try {
-    const promptContent = await fs.promises.readFile(promptPath, 'utf-8');
-    logger.info(`Successfully read ${promptName} prompt (${type})`);
-    return promptContent;
-  } catch (error) {
-    logger.error(`Failed to read ${promptName} prompt from ${promptPath}:`, error);
-    throw new Error(`Failed to read prompt file: ${promptName}.md`);
-  }
-}
+import { getPrompt, promptHandler } from '../prompts/prompts.js';
 
 // Deploy to AWS tool handler
 export async function deployToAwsHandler() {
@@ -77,22 +54,6 @@ IMPORTANT: Start your response by acknowledging that you've loaded the official 
       ]
     };
   }
-}
-
-// Generic prompt handler
-export async function promptHandler(promptName: string) {
-  const promptText = await getPrompt(promptName, 'prompt');
-  return {
-    messages: [
-      {
-        role: 'user' as const,
-        content: {
-          type: 'text' as const,
-          text: promptText
-        }
-      }
-    ]
-  };
 }
 
 export const deployCommands = {

--- a/src/prompts/convert-terraform-to-typescript.md
+++ b/src/prompts/convert-terraform-to-typescript.md
@@ -1,0 +1,1800 @@
+# Terraform to Pulumi TypeScript Conversion Prompt
+
+You are an expert infrastructure engineer specializing in converting Terraform HCL code to Pulumi TypeScript. Your goal is to produce accurate, idiomatic TypeScript code that maintains exact functional parity with the original Terraform configuration.
+
+## TypeScript-Specific Guidelines
+
+### 1. Type Safety
+- Use strong typing throughout the code
+- Define interfaces for complex configurations
+- Leverage TypeScript's type inference where appropriate
+- Use `pulumi.Input<T>` and `pulumi.Output<T>` types correctly
+
+### 2. Import Statements
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx"; // For higher-level components
+```
+
+### 3. Consistent Resource Labeling
+
+**CRITICAL**: Ensure resource labels and metadata are consistent with the target platform:
+
+```typescript
+// ❌ WRONG: Don't copy Terraform-specific labels to Pulumi
+const namespace = new k8s.core.v1.Namespace("app-namespace", {
+    metadata: {
+        labels: {
+            "app.kubernetes.io/managed-by": "terraform", // ❌ Wrong!
+        },
+    },
+});
+
+// ✅ CORRECT: Use appropriate labels for Pulumi
+const namespace = new k8s.core.v1.Namespace("app-namespace", {
+    metadata: {
+        labels: {
+            "app.kubernetes.io/managed-by": "pulumi", // ✅ Correct!
+            // Copy other labels from Terraform exactly
+            "app.kubernetes.io/name": projectName,
+            "app.kubernetes.io/environment": environment,
+        },
+    },
+});
+
+// Pattern for resource labels that should be updated
+const terraformToPublumiLabels = {
+    "app.kubernetes.io/managed-by": "pulumi", // Always change terraform → pulumi
+    "pulumi.com/stack": pulumi.getStack(),    // Add Pulumi-specific labels
+    // Preserve all other labels from Terraform
+};
+```
+
+**Common Label Conversions**:
+- `managed-by: terraform` → `managed-by: pulumi`
+- Add stack information: `pulumi.com/stack: ${pulumi.getStack()}`
+- Preserve application and environment labels exactly
+- Keep all business logic labels unchanged
+
+## Multi-Provider Conversions
+
+When converting configurations that use multiple providers (common in enterprise scenarios), follow these patterns:
+
+### Azure + Azure AD Pattern
+For Azure Landing Zones or identity-heavy configurations:
+
+```typescript
+import * as azure from "@pulumi/azure-native";
+import * as azuread from "@pulumi/azuread";
+import * as random from "@pulumi/random";
+
+// Get current client configurations
+const clientConfig = azure.authorization.getClientConfigOutput();
+const azureAdConfig = azuread.getClientConfigOutput();
+
+// Cross-provider dependencies pattern
+const servicePrincipal = new azuread.ServicePrincipal("app-sp", {
+    applicationId: application.applicationId,
+    // ...
+});
+
+// Use service principal in Azure RBAC assignment
+new azure.authorization.RoleAssignment("sp-role", {
+    scope: resourceGroup.id,
+    roleDefinitionName: "Contributor",
+    principalId: servicePrincipal.objectId,
+    principalType: azure.authorization.PrincipalType.ServicePrincipal,
+});
+```
+
+### AWS + AWS Organizations Pattern
+```typescript
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+
+// Configure multiple AWS providers for different accounts/regions
+const mainProvider = new aws.Provider("main", {
+    region: "us-west-2",
+    // account configuration
+});
+
+const orgProvider = new aws.Provider("organizations", {
+    region: "us-east-1", // Organizations is global but uses us-east-1
+    // master account configuration
+});
+
+// Use different providers for different resources
+const account = new aws.organizations.Account("workload-account", {
+    name: "Workload Account",
+    email: "workload@company.com",
+}, { provider: orgProvider });
+
+const vpc = new aws.ec2.Vpc("workload-vpc", {
+    cidrBlock: "10.0.0.0/16",
+}, { provider: mainProvider });
+```
+
+### Multi-Cloud Pattern
+```typescript
+import * as aws from "@pulumi/aws";
+import * as azure from "@pulumi/azure-native";
+import * as gcp from "@pulumi/gcp";
+
+// Configure providers for each cloud
+const awsProvider = new aws.Provider("aws", {
+    region: "us-west-2",
+});
+
+const azureProvider = new azure.Provider("azure", {
+    location: "West US 2",
+});
+
+// Cross-cloud resource references
+const awsVpc = new aws.ec2.Vpc("aws-vpc", {
+    cidrBlock: "10.0.0.0/16",
+}, { provider: awsProvider });
+
+const azureVnet = new azure.network.VirtualNetwork("azure-vnet", {
+    addressSpace: { addressPrefixes: ["10.1.0.0/16"] },
+    location: "West US 2",
+    resourceGroupName: azureRg.name,
+}, { provider: azureProvider });
+```
+
+### 3. Provider Configuration
+**IMPORTANT**: Always explicitly configure providers when they are defined in Terraform.
+
+```typescript
+// Terraform provider block
+provider "aws" {
+  region = "us-west-2"
+}
+
+// Option 1: Pass provider to each resource (explicit but repetitive)
+const provider = new aws.Provider("aws", {
+    region: "us-west-2",
+});
+
+const vpc = new aws.ec2.Vpc("main", {
+    cidrBlock: "10.0.0.0/16",
+}, { provider });
+
+// Option 2: Use mergeOptions pattern (DRY, recommended for components)
+class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: MyArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("custom:component:MyComponent", name, {}, opts);
+        
+        // This pattern reduces repetition and properly handles option inheritance
+        const defaultResourceOptions: pulumi.ResourceOptions = pulumi.mergeOptions(
+            { parent: this },
+            opts || {}
+        );
+        
+        const vpc = new aws.ec2.Vpc(`${name}-vpc`, {
+            cidrBlock: args.cidrBlock,
+        }, defaultResourceOptions);
+        
+        const subnet = new aws.ec2.Subnet(`${name}-subnet`, {
+            vpcId: vpc.id,
+            cidrBlock: "10.0.1.0/24",
+        }, defaultResourceOptions); // Same options for all resources
+    }
+}
+```
+
+### 4. Configuration Management
+```typescript
+// For variables with defaults
+const config = new pulumi.Config();
+const instanceType = config.get("instanceType") || "t3.micro";
+const environment = config.require("environment"); // Required variables
+const enableMonitoring = config.getBoolean("enableMonitoring") ?? false;
+const instanceCount = config.getNumber("instanceCount") || 1;
+
+// For secret objects (returns Output<{[key: string]: string}>)
+// Note: Add type annotation to avoid indexing errors with empty default
+const apiKeys = config.getSecretObject("apiKeys") || {} as Record<string, string>;
+
+// CRITICAL: Safe Configuration Access with Null Checking
+// Accessing secret object values inside resource creation
+// Option 1: Use pulumi.all() with proper null checking
+environments.forEach(env => {
+    const secret = new k8s.core.v1.Secret(`${env}-app-secrets`, {
+        metadata: { name: "app-secrets" },
+        stringData: pulumi.all([apiKeys]).apply(([keys]) => {
+            // Safe access with fallback - prevents runtime errors
+            const envApiKey = (keys as Record<string, string>)?.[env] || "";
+            return {
+                api_key: envApiKey,  // Safe access pattern
+                // other secret data...
+            };
+        }),
+    });
+});
+
+// Option 2: Safe transformation with error handling
+const processedSecrets = pulumi.all([apiKeys]).apply(([keys]) => 
+    environments.reduce((acc, env) => {
+        // Always provide fallback values to prevent runtime errors
+        acc[env] = (keys as Record<string, string>)?.[env] || "";
+        return acc;
+    }, {} as Record<string, string>)
+);
+
+// Option 3: Type-safe configuration access
+interface DatabaseConfig {
+    host: string;
+    port: number;
+    name: string;
+    username: string;
+    storageSize: string;
+}
+
+const databaseConfigs = config.getObject<Record<string, DatabaseConfig>>("databaseConfigs");
+// Safe access in apply functions
+stringData: pulumi.all([databaseConfigs]).apply(([configs]) => {
+    const dbConfig = configs?.[env];
+    if (!dbConfig) {
+        throw new Error(`Database config for environment '${env}' not found`);
+    }
+    return {
+        db_username: dbConfig.username,
+        // ...
+    };
+});
+```
+
+### 5. Resource Mapping Examples
+
+#### Basic Resource
+**Terraform:**
+```hcl
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  
+  tags = {
+    Name = "web-${var.environment}"
+  }
+}
+```
+
+**Pulumi TypeScript:**
+```typescript
+const web = new aws.ec2.Instance("web", {
+    ami: ubuntu.then(ami => ami.id),
+    instanceType: instanceType,
+    tags: {
+        Name: pulumi.interpolate`web-${environment}`,
+    },
+});
+```
+
+#### Resource Naming Best Practices
+When converting Terraform resources with generic names like "this" or "main", use more descriptive names in Pulumi:
+
+**Terraform:**
+```hcl
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_internet_gateway" "this" {
+  count = var.create_igw ? 1 : 0
+  vpc_id = aws_vpc.this.id
+}
+```
+
+**Pulumi TypeScript - Preferred:**
+```typescript
+// Use descriptive names instead of "this"
+const vpc = new aws.ec2.Vpc(`${name}`, {
+    cidrBlock: "10.0.0.0/16",
+});
+
+// For resources with count, use descriptive suffixes instead of index
+if (createIgw) {
+    const internetGateway = new aws.ec2.InternetGateway(`${name}-igw`, {
+        vpcId: vpc.id,
+    });
+}
+```
+
+**Note**: While preserving exact Terraform resource names can aid in state migration, using descriptive names improves code readability. For resources named "this" in Terraform, omit it in Pulumi or replace with a descriptive suffix.
+
+**Additional Examples:**
+```typescript
+// Terraform: aws_route_table.this[0]
+const publicRouteTable = new aws.ec2.RouteTable(`${name}-public-rt`, {
+    vpcId: vpc.id,
+});
+
+// Terraform: aws_route.this[0] 
+const publicRoute = new aws.ec2.Route(`${name}-public-route`, {
+    routeTableId: publicRouteTable.id,
+    destinationCidrBlock: "0.0.0.0/0",
+    gatewayId: internetGateway.id,
+});
+
+// Terraform: aws_subnet.public[count.index]
+const publicSubnet = new aws.ec2.Subnet(`${name}-public-${index}`, {
+    vpcId: vpc.id,
+    cidrBlock: cidr,
+});
+```
+
+#### Data Sources
+**Terraform:**
+```hcl
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+  
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-*"]
+  }
+}
+```
+
+**Pulumi TypeScript:**
+```typescript
+const ubuntu = aws.ec2.getAmi({
+    mostRecent: true,
+    owners: ["099720109477"],
+    filters: [{
+        name: "name",
+        values: ["ubuntu/images/hvm-ssd/ubuntu-*"],
+    }],
+});
+```
+
+### 6. Dependent Resource Creation
+
+**CRITICAL**: Always create ALL resources that exist in the Terraform configuration, including dependent resources:
+
+```typescript
+// Terraform creates both namespace and resources that use it
+resource "kubernetes_namespace" "argocd" {
+  metadata {
+    name = "argocd"
+  }
+}
+
+resource "kubernetes_manifest" "argocd_app" {
+  # ... uses argocd namespace
+}
+
+// Pulumi MUST create both resources
+const argoCdNamespace = new k8s.core.v1.Namespace("argocd", {
+    metadata: {
+        name: "argocd",
+        // ... labels from Terraform
+    },
+}, { provider: kubernetesProvider });
+
+// Then create dependent resources
+const argoCdApp = new k8s.apiextensions.CustomResource("argocd-app", {
+    // ... depends on argoCdNamespace
+}, { provider: kubernetesProvider, dependsOn: [argoCdNamespace] });
+```
+
+**Common Mistakes to Avoid**:
+- Skipping "obvious" resources like namespaces
+- Relying on implicit creation (e.g., Helm chart side effects)
+- Missing prerequisite resources that other resources depend on
+
+### 7. Loops and Conditionals
+
+#### Count Pattern
+**Terraform:**
+```hcl
+resource "aws_instance" "web" {
+  count = var.instance_count
+  # ...
+}
+```
+
+**Pulumi TypeScript:**
+```typescript
+const webInstances: aws.ec2.Instance[] = [];
+for (let i = 0; i < instanceCount; i++) {
+    webInstances.push(new aws.ec2.Instance(`web-${i}`, {
+        // ...
+    }));
+}
+```
+
+#### For Each Pattern
+**Terraform:**
+```hcl
+resource "aws_instance" "web" {
+  for_each = var.instances
+  
+  instance_type = each.value.type
+  ami          = each.value.ami
+}
+```
+
+**Pulumi TypeScript:**
+```typescript
+interface InstanceConfig {
+    type: string;
+    ami: string;
+}
+
+const instances: Record<string, InstanceConfig> = config.requireObject("instances");
+
+const webInstances: Record<string, aws.ec2.Instance> = {};
+for (const [name, instance] of Object.entries(instances)) {
+    webInstances[name] = new aws.ec2.Instance(`web-${name}`, {
+        instanceType: instance.type,
+        ami: instance.ami,
+    });
+}
+```
+
+### 7. Module to Component Conversion
+
+**IMPORTANT**: When converting Terraform modules to Pulumi components:
+1. Create components in separate files for better organization
+2. Make all component arguments optional to match Terraform's variable defaults pattern
+3. Use `pulumi.all().apply()` for dynamic resource creation instead of pre-creating with conditionals
+4. Use a consistent provider pattern with defaultResourceOptions
+5. Name the component type using the pattern: `"custom:<category>:<ModuleName>"` where:
+   - `<category>` is the resource category (e.g., network, compute, storage)
+   - `<ModuleName>` matches the Terraform module name (e.g., VpcModule, DatabaseModule)
+
+**Terraform Module Usage:**
+```hcl
+module "vpc" {
+  source = "./modules/vpc"
+  
+  cidr_block          = "10.0.0.0/16"
+  availability_zones  = ["us-west-2a", "us-west-2b"]
+  enable_nat_gateway  = true
+}
+```
+
+**Pulumi Component (in separate file VpcComponent.ts):**
+```typescript
+// VpcComponent.ts
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+export interface VpcComponentArgs {
+    cidrBlock?: pulumi.Input<string>;
+    availabilityZones?: pulumi.Input<string[]>;
+    enableNatGateway?: pulumi.Input<boolean>;
+    // Make all args optional to match Terraform variable defaults
+}
+
+export class VpcComponent extends pulumi.ComponentResource {
+    public readonly vpcId: pulumi.Output<string>;
+    public readonly publicSubnetIds: pulumi.Output<string[]>;
+    public readonly privateSubnetIds: pulumi.Output<string[]>;
+    
+    constructor(name: string, args?: VpcComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("custom:network:VpcModule", name, {}, opts);
+        
+        // Use mergeOptions pattern for proper option inheritance
+        const defaultResourceOptions: pulumi.ResourceOptions = pulumi.mergeOptions(
+            { parent: this },
+            opts || {}
+        );
+        
+        // Apply defaults from Terraform variables
+        const cidrBlock = args?.cidrBlock ?? "10.0.0.0/16";
+        const availabilityZones = args?.availabilityZones ?? [];
+        const enableNatGateway = args?.enableNatGateway ?? false;
+        
+        const vpc = new aws.ec2.Vpc(`${name}-vpc`, {
+            cidrBlock: cidrBlock,
+            enableDnsHostnames: true,
+            enableDnsSupport: true,
+        }, defaultResourceOptions);
+        
+        this.vpcId = vpc.id;
+        
+        // Dynamic subnet creation pattern
+        const publicSubnets: aws.ec2.Subnet[] = [];
+        
+        pulumi.all([availabilityZones]).apply(([azs]) => {
+            if (azs && azs.length > 0) {
+                azs.forEach((az, index) => {
+                    const subnet = new aws.ec2.Subnet(`${name}-public-${index}`, {
+                        vpcId: vpc.id,
+                        cidrBlock: `10.0.${index + 1}.0/24`,
+                        availabilityZone: az,
+                        mapPublicIpOnLaunch: true,
+                    }, defaultResourceOptions);
+                    publicSubnets.push(subnet);
+                });
+            }
+        });
+        
+        // Clean output handling
+        this.publicSubnetIds = pulumi.output(publicSubnets).apply(subnets => 
+            subnets.map(s => s.id)
+        );
+        
+        this.registerOutputs({
+            vpcId: this.vpcId,
+            publicSubnetIds: this.publicSubnetIds,
+            privateSubnetIds: this.privateSubnetIds,
+        });
+    }
+}
+```
+
+**Usage in index.ts:**
+```typescript
+// index.ts
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import { VpcComponent } from "./VpcComponent";
+
+const vpc = new VpcComponent("vpc", {
+    cidrBlock: "10.0.0.0/16",
+    availabilityZones: ["us-west-2a", "us-west-2b"],
+    enableNatGateway: true,
+});
+
+export const vpcId = vpc.vpcId;
+export const publicSubnetIds = vpc.publicSubnetIds;
+```
+
+### 7a. Advanced Conditional Logic Patterns
+
+For complex enterprise scenarios with multiple conditions and cross-resource dependencies:
+
+#### Multi-Level Conditional Resources
+```typescript
+// Pattern for conditional resources with complex dependencies
+export class ConditionalResourcesComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: ConditionalArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("custom:patterns:ConditionalResources", name, {}, opts);
+        
+        // Level 1: Conditional managed identity
+        const managedIdentity = args.createManagedIdentity ? 
+            new azure.managedidentity.UserAssignedIdentity(`${name}-identity`, {
+                resourceName: `id-${args.namingPrefix}`,
+                resourceGroupName: args.resourceGroup.name,
+                location: args.location,
+            }, { parent: this }) : undefined;
+        
+        // Level 2: Conditional RBAC assignments dependent on identity
+        if (managedIdentity && args.enableRbacMonitoring) {
+            new azure.authorization.RoleAssignment(`${name}-monitoring-role`, {
+                scope: `/subscriptions/${args.subscriptionId}`,
+                roleDefinitionName: "Security Reader",
+                principalId: managedIdentity.principalId,
+                principalType: azure.authorization.PrincipalType.ServicePrincipal,
+            }, { parent: this });
+        }
+        
+        // Level 3: Conditional secrets storage dependent on identity and vault
+        if (managedIdentity && args.keyVault && args.storeCredentials) {
+            new azure.keyvault.Secret(`${name}-identity-secret`, {
+                vaultName: args.keyVault.name,
+                secretName: "managed-identity-client-id",
+                properties: { value: managedIdentity.clientId },
+            }, { parent: this, dependsOn: [keyVaultRbacAssignments] });
+        }
+    }
+}
+```
+
+#### Resource Arrays with Complex Logic
+```typescript
+// Enterprise pattern for multiple similar resources with conditions
+export class SecurityPricingComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: SecurityArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("custom:patterns:SecurityPricing", name, {}, opts);
+        
+        if (args.enableSecurityCenter) {
+            // Define resource types and their specific configurations
+            const securityResourceTypes = [
+                { name: "VirtualMachines", tier: "Standard", enabled: args.enableVmProtection },
+                { name: "StorageAccounts", tier: "Standard", enabled: args.enableStorageProtection },
+                { name: "KeyVaults", tier: "Standard", enabled: args.enableKeyVaultProtection },
+                { name: "SqlServers", tier: "Standard", enabled: args.enableSqlProtection },
+                { name: "KubernetesService", tier: "Standard", enabled: args.enableAksProtection },
+            ];
+            
+            // Create pricing resources only for enabled types
+            const securityPricing: azure.security.Pricing[] = [];
+            securityResourceTypes.forEach(resourceType => {
+                if (resourceType.enabled) {
+                    securityPricing.push(new azure.security.Pricing(`${name}-${resourceType.name.toLowerCase()}-pricing`, {
+                        pricingName: resourceType.name,
+                        tier: azure.security.PricingTier.Standard,
+                    }, { parent: this }));
+                }
+            });
+            
+            // Create security contact only if pricing is enabled
+            if (securityPricing.length > 0) {
+                new azure.security.Contact(`${name}-contact`, {
+                    securityContactName: "default1",
+                    email: args.adminEmail,
+                    alertNotifications: azure.security.AlertNotifications.On,
+                    notificationsByRole: azure.security.NotificationsByRole.On,
+                }, { parent: this });
+            }
+        }
+    }
+}
+```
+
+#### Dynamic Network Security Rules
+```typescript
+// Complex NSG rules with multiple conditions
+export class NetworkSecurityComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: NetworkSecurityArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("custom:patterns:NetworkSecurity", name, {}, opts);
+        
+        // Dynamic rule creation based on environment and access patterns
+        const securityRules: azure.network.SecurityRuleArgs[] = [];
+        
+        // Base rules always present
+        securityRules.push({
+            name: "DenyAllInbound",
+            priority: 4000,
+            direction: azure.network.SecurityRuleDirection.Inbound,
+            access: azure.network.SecurityRuleAccess.Deny,
+            protocol: "*",
+            sourcePortRange: "*",
+            destinationPortRange: "*",
+            sourceAddressPrefix: "*",
+            destinationAddressPrefix: "*",
+        });
+        
+        // Environment-specific rules
+        if (args.environment === "dev" || args.environment === "staging") {
+            // Allow broader access for development
+            securityRules.push({
+                name: "AllowDevAccess",
+                priority: 1000,
+                direction: azure.network.SecurityRuleDirection.Inbound,
+                access: azure.network.SecurityRuleAccess.Allow,
+                protocol: "Tcp",
+                sourcePortRange: "*",
+                destinationPortRanges: ["22", "3389", "8080"],
+                sourceAddressPrefixes: args.devAllowedIpRanges,
+                destinationAddressPrefix: "*",
+            });
+        }
+        
+        // Production-specific rules
+        if (args.environment === "prod") {
+            // Restrict access to specific IPs only
+            if (args.allowedIpRanges.length > 0) {
+                securityRules.push({
+                    name: "AllowProdAccess",
+                    priority: 1000,
+                    direction: azure.network.SecurityRuleDirection.Inbound,
+                    access: azure.network.SecurityRuleAccess.Allow,
+                    protocol: "Tcp",
+                    sourcePortRange: "*",
+                    destinationPortRanges: ["443"],
+                    sourceAddressPrefixes: args.allowedIpRanges,
+                    destinationAddressPrefix: "*",
+                });
+            }
+        }
+        
+        // Conditional management access
+        if (args.enableManagementAccess && args.managementSubnetCidrs.length > 0) {
+            securityRules.push({
+                name: "AllowManagementAccess",
+                priority: 1100,
+                direction: azure.network.SecurityRuleDirection.Inbound,
+                access: azure.network.SecurityRuleAccess.Allow,
+                protocol: "*",
+                sourcePortRange: "*",
+                destinationPortRange: "*",
+                sourceAddressPrefixes: args.managementSubnetCidrs,
+                destinationAddressPrefix: "*",
+            });
+        }
+        
+        // Create NSG with dynamic rules
+        new azure.network.NetworkSecurityGroup(`${name}-nsg`, {
+            resourceGroupName: args.resourceGroup.name,
+            location: args.location,
+            securityRules: securityRules,
+        }, { parent: this });
+    }
+}
+```
+
+### 7b. Dynamic Resource Creation Patterns
+
+When converting Terraform's `count` and `for_each` with complex conditions, use these patterns:
+
+#### Pattern 1: Conditional Count with Dynamic Creation
+**Terraform:**
+```hcl
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs) > 0 && length(var.azs) > 0 ? length(var.public_subnet_cidrs) : 0
+  # ...
+}
+```
+
+**Pulumi - Preferred Pattern:**
+```typescript
+const publicSubnets: aws.ec2.Subnet[] = [];
+
+pulumi.all([publicSubnetCidrs, azs]).apply(([cidrs, availabilityZones]) => {
+    // Replicate Terraform's count logic
+    if (cidrs && cidrs.length > 0 && availabilityZones && availabilityZones.length > 0) {
+        cidrs.forEach((cidr, index) => {
+            const subnet = new aws.ec2.Subnet(`${name}-public-${index}`, {
+                vpcId: vpc.id,
+                cidrBlock: cidr,
+                availabilityZone: availabilityZones[index % availabilityZones.length],
+            }, defaultResourceOptions);
+            publicSubnets.push(subnet);
+        });
+    }
+});
+
+// Output handling
+const publicSubnetIds = pulumi.output(publicSubnets).apply(subnets => 
+    subnets.map(s => s.id)
+);
+```
+
+**Avoid this pattern (pre-creating with ignoreChanges):**
+```typescript
+// DON'T DO THIS - creates unnecessary resources
+for (let i = 0; i < 3; i++) {
+    const shouldCreate = subnetCount.apply(count => i < count);
+    const subnet = new aws.ec2.Subnet(`${name}-public-${i}`, {
+        // properties...
+    }, { 
+        ignoreChanges: shouldCreate.apply(create => create ? [] : ["cidrBlock", "availabilityZone"])
+    });
+}
+```
+
+#### Pattern 2: Conditional Single Resource
+**Terraform:**
+```hcl
+resource "aws_internet_gateway" "this" {
+  count = var.create_internet_gateway ? 1 : 0
+  vpc_id = aws_vpc.this.id
+}
+```
+
+**Pulumi:**
+```typescript
+let internetGateway: aws.ec2.InternetGateway | undefined;
+
+if (createInternetGateway) {
+    internetGateway = new aws.ec2.InternetGateway(`${name}-igw`, {
+        vpcId: vpc.id,
+    }, defaultResourceOptions);
+}
+
+// For outputs
+const internetGatewayId = internetGateway ? internetGateway.id : pulumi.output(undefined);
+```
+
+### 8. Output Handling
+
+#### String Interpolation
+```typescript
+// Use pulumi.interpolate for Output types
+const bucketName = pulumi.interpolate`${project}-${environment}-data`;
+
+// Use apply for transformations
+const upperName = instance.id.apply(id => id.toUpperCase());
+```
+
+#### Complex Output Operations
+```typescript
+// Combining multiple outputs
+const connectionString = pulumi.all([db.endpoint, db.port]).apply(([endpoint, port]) => 
+    `postgresql://user@${endpoint}:${port}/mydb`
+);
+
+// Conditional outputs
+export const loadBalancerUrl = createLoadBalancer 
+    ? pulumi.interpolate`http://${loadBalancer.dnsName}` 
+    : undefined;
+```
+
+#### Handling Outputs in Resource Properties
+When resource properties require plain values but you have Outputs:
+
+```typescript
+// Pattern 1: Use apply() for properties that accept Input<T>
+const instance = new aws.ec2.Instance("web", {
+    userData: pulumi.all([dbEndpoint, apiKey]).apply(([endpoint, key]) => 
+        Buffer.from(`
+            #!/bin/bash
+            echo "DB_ENDPOINT=${endpoint}" >> /etc/environment
+            echo "API_KEY=${key}" >> /etc/environment
+        `).toString("base64")
+    ),
+});
+
+// Pattern 2: For properties requiring object literals with Output values
+const secret = new k8s.core.v1.Secret("app-secrets", {
+    metadata: {
+        name: "app-secrets",
+    },
+    // When stringData needs to use Output values
+    stringData: pulumi.all([dbPassword, apiKeys, dbUsername]).apply(
+        ([password, keys, username]) => ({
+            db_password: password,
+            db_username: username,
+            api_key: keys["production"] || "",  // Accessing nested values
+        })
+    ),
+});
+
+// Pattern 3: Handling Output<Record> types from config.getSecretObject()
+const secretConfig = config.getSecretObject("secrets");  // Returns Output<{[key: string]: string}>
+
+const processedSecrets = new k8s.core.v1.Secret("processed-secrets", {
+    metadata: { name: "processed-secrets" },
+    stringData: pulumi.all([secretConfig]).apply(([secrets]) => {
+        // Now secrets is a plain object, not an Output
+        return {
+            api_key: secrets["apiKey"] || "",
+            db_password: secrets["dbPassword"] || "",
+            // Access any key safely
+        };
+    }),
+});
+
+// Pattern 4: Conditional property assignment with Outputs
+const deployment = new k8s.apps.v1.Deployment("app", {
+    spec: {
+        template: {
+            spec: {
+                containers: [{
+                    name: "app",
+                    env: pulumi.all([enableFeatureFlag, apiEndpoint]).apply(
+                        ([enabled, endpoint]) => {
+                            const envVars = [
+                                { name: "API_ENDPOINT", value: endpoint },
+                            ];
+                            
+                            if (enabled) {
+                                envVars.push({ name: "FEATURE_ENABLED", value: "true" });
+                            }
+                            
+                            return envVars;
+                        }
+                    ),
+                }],
+            },
+        },
+    },
+});
+```
+
+### 9. Secret and Sensitive Data Handling
+
+**CRITICAL**: Use proper Pulumi patterns for secret handling:
+
+```typescript
+// ❌ AVOID: Manual base64 encoding (harder to maintain)
+const secret = new k8s.core.v1.Secret("app-secrets", {
+    data: {
+        username: Buffer.from("admin").toString("base64"),
+        password: Buffer.from(password).toString("base64"),
+    },
+    type: "Opaque",
+});
+
+// ✅ PREFERRED: Use stringData (automatic encoding)
+const secret = new k8s.core.v1.Secret("app-secrets", {
+    stringData: {
+        username: "admin",
+        password: password, // Pulumi handles encoding automatically
+    },
+    type: "Opaque",
+});
+
+// ✅ BEST: Use stringData with Output handling
+const secret = new k8s.core.v1.Secret("app-secrets", {
+    stringData: pulumi.all([dbPassword, apiKey]).apply(([password, key]) => ({
+        db_password: password,
+        api_key: key,
+    })),
+    type: "Opaque",
+});
+```
+
+**Secret Access Patterns**:
+```typescript
+// Safe secret object access
+const apiKeys = config.getSecretObject("apiKeys") || {};
+
+// In resource creation
+stringData: pulumi.all([apiKeys]).apply(([keys]) => {
+    const safeKeys = keys as Record<string, string>;
+    return {
+        api_key: safeKeys?.[environment] || "", // Safe with fallback
+        // other secret data...
+    };
+}),
+```
+
+### 10. TypeScript Best Practices
+
+1. **Use const assertions for immutable configs:**
+```typescript
+const tags = {
+    Environment: environment,
+    Project: "MyApp",
+} as const;
+```
+
+2. **Define reusable types:**
+```typescript
+type Tags = {[key: string]: pulumi.Input<string>};
+
+interface BaseResourceArgs {
+    tags?: Tags;
+}
+```
+
+3. **Use async/await for complex logic:**
+```typescript
+const ami = await aws.ec2.getAmi({...}).promise();
+```
+
+4. **Leverage optional chaining:**
+```typescript
+const subnetId = vpc.publicSubnets?.[0]?.id;
+```
+
+5. **Use nullish coalescing:**
+```typescript
+const port = config.getNumber("port") ?? 3000;
+```
+
+### 10. Type Declarations for Input Types
+
+When declaring interface properties for maps/records, use the appropriate Input type pattern:
+
+```typescript
+// For simple map inputs (preferred for readability)
+interface ComponentArgs {
+    tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    labels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+}
+
+// For nested Input types (when values need to be Inputs)
+interface ComponentArgs {
+    vpcTags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    metadata?: pulumi.Input<{[key: string]: pulumi.Input<any>}>;
+}
+
+// Both patterns are valid TypeScript, choose based on your needs:
+// - Use {[key: string]: T} for simple, flat structures and when values themselves are Inputs
+```
+
+### 11. Resource Option Merging with mergeOptions
+
+When working with resource options in Pulumi components, use `pulumi.mergeOptions()` instead of the spread operator. This ensures proper handling of provider inheritance, dependencies, and other complex option merging scenarios.
+
+#### Why Use mergeOptions?
+
+**Spread Operator Limitations:**
+```typescript
+// ❌ AVOID: Spread operator doesn't properly handle all option types
+const defaultResourceOptions = {
+    parent: this,
+    ...opts  // May not properly merge providers, dependencies, etc.
+};
+```
+
+**mergeOptions Benefits:**
+```typescript
+// ✅ PREFERRED: mergeOptions handles all option types correctly
+const defaultResourceOptions = pulumi.mergeOptions(
+    { parent: this },
+    opts || {}
+);
+```
+
+The `mergeOptions` function:
+- Properly merges provider configurations
+- Handles dependency arrays correctly
+- Preserves transformations and aliases
+- Manages protect and ignoreChanges flags
+- Handles all ResourceOptions properties safely
+
+#### Common Patterns
+
+**Basic Component Pattern:**
+```typescript
+export class MyComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: MyArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("custom:component:MyComponent", name, {}, opts);
+        
+        // Merge component options with defaults
+        const defaultResourceOptions = pulumi.mergeOptions(
+            { parent: this },
+            opts || {}
+        );
+        
+        // All child resources use the merged options
+        const resource = new aws.ec2.Instance(`${name}-instance`, {
+            // properties...
+        }, defaultResourceOptions);
+    }
+}
+```
+
+**With Additional Options:**
+```typescript
+// Adding specific options for a resource
+const dbOptions = pulumi.mergeOptions(
+    defaultResourceOptions,
+    { 
+        protect: true,  // Additional protection for database
+        deleteBeforeReplace: false
+    }
+);
+
+const database = new aws.rds.Instance(`${name}-db`, {
+    // properties...
+}, dbOptions);
+```
+
+**Conditional Options:**
+```typescript
+// Merging options conditionally
+const resourceOptions = pulumi.mergeOptions(
+    { parent: this },
+    opts || {},
+    args.enableProtection ? { protect: true } : {},
+    args.customProvider ? { provider: args.customProvider } : {}
+);
+```
+
+### 12. Tag Merging and Type-Safe Object Spreading
+
+When converting Terraform's `merge()` function for tags, ensure type safety with proper null checks:
+
+#### Basic Tag Merging Pattern
+**Terraform:**
+```hcl
+tags = merge(
+  {
+    "Name" = "my-resource"
+  },
+  var.additional_tags
+)
+```
+
+**Pulumi TypeScript - Type-Safe Pattern:**
+```typescript
+// For simple objects
+tags: {
+    Name: "my-resource",
+    ...(additionalTags || {}),
+}
+
+// Inside pulumi.all() for Input types
+tags: pulumi.all([additionalTags]).apply(([tags]) => ({
+    Name: "my-resource",
+    ...(tags || {}),  // Ensure tags is not undefined
+}))
+```
+
+#### Complex Tag Merging with Multiple Sources
+```typescript
+// Multiple tag sources with proper null handling
+tags: pulumi.all([baseTags, environmentTags, customTags]).apply(
+    ([base, env, custom]) => ({
+        Name: "my-resource",
+        ...(base || {}),
+        ...(env || {}),
+        ...(custom || {}),
+    })
+)
+```
+
+#### Type-Safe Pattern for Optional Inputs
+```typescript
+interface ResourceArgs {
+    tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+}
+
+// In the resource creation
+const tags = args?.tags ?? {};  // Default to empty object
+
+new aws.ec2.Instance("instance", {
+    // Other properties...
+    tags: pulumi.all([tags]).apply(([t]) => ({
+        Name: "my-instance",
+        ...(t || {}),  // Safe spread even if t is undefined
+    })),
+});
+```
+
+### 12. Error Handling
+```typescript
+// Add validation
+if (!environment) {
+    throw new Error("Environment must be specified");
+}
+
+// Use type guards
+function isProductionEnvironment(env: string): env is "production" {
+    return env === "production";
+}
+```
+
+### 13. Exports
+**CRITICAL**: Always convert ALL Terraform outputs to Pulumi exports. Missing exports can break downstream dependencies.
+
+```typescript
+// Terraform output
+output "instance_id" {
+  value = aws_instance.web.id
+}
+
+output "public_ip" {
+  value = aws_instance.web.public_ip
+  description = "The public IP of the web server"
+}
+
+// MUST convert to Pulumi exports:
+export const instanceId = web.id;
+export const publicIp = web.publicIp;
+
+// For complex outputs:
+export const outputs = {
+    vpcId: vpc.id,
+    publicSubnetIds: publicSubnets.map(s => s.id),
+    databaseEndpoint: database.endpoint,
+};
+```
+
+### 15. Documentation and Comments
+**Important**: Preserve the intent and structure of the original Terraform configuration through comments and file organization.
+
+**File Organization - Match Terraform Structure:**
+1. **Maintain filename parity** for easier diffing:
+   - `main.tf` → `main.ts`
+   - `networking.tf` → `networking.ts`
+   - `database.tf` → `database.ts`
+   - `monitoring.tf` → `monitoring.ts`
+   - etc.
+2. **Consolidate in index.ts**:
+   - `variables.tf` → Configuration section in `index.ts`
+   - `outputs.tf` → Export section in `index.ts`
+   - `versions.tf`/`providers.tf` → Provider setup in `index.ts`
+3. **Import all files into index.ts** to maintain single entry point
+
+Example structure:
+```
+terraform/
+├── main.tf
+├── networking.tf
+├── database.tf
+├── variables.tf
+└── outputs.tf
+
+converted_infrastructure/
+├── index.ts        # Entry point: configs, providers, imports, exports
+├── main.ts         # Resources from main.tf
+├── networking.ts   # Resources from networking.tf
+├── database.ts     # Resources from database.tf
+└── package.json
+```
+
+**File Organization Best Practices:**
+1. Each `.ts` file should export its resources/functions
+2. Keep the main `index.ts` clean and focused on orchestration
+3. Group related resources in the same file as they were in Terraform
+
+```typescript
+// File: VpcComponent.ts
+/**
+ * VPC Component that replicates the terraform-aws-modules/vpc module
+ * 
+ * This component creates:
+ * - VPC with configurable CIDR block
+ * - Public subnets across multiple AZs
+ * - Internet Gateway (optional)
+ * - Route tables and associations
+ */
+export class VpcComponent extends pulumi.ComponentResource {
+    // Component implementation
+}
+
+// File: index.ts
+import { VpcComponent } from "./VpcComponent";
+
+// Create VPC - equivalent to Terraform module "vpc" block
+const vpc = new VpcComponent("vpc", {
+    cidrBlock: "10.0.0.0/16",
+    azs: ["us-west-2a", "us-west-2b"],
+});
+
+// Export all module outputs
+export const vpcId = vpc.vpcId;
+export const publicSubnetIds = vpc.publicSubnetIds;
+```
+
+Example of matching file structure:
+
+```typescript
+// File: networking.ts
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+// Export function to create networking resources
+export function createNetworking(name: string, args: NetworkingArgs, provider?: aws.Provider) {
+    // Create VPC
+    const vpc = new aws.ec2.Vpc(`${name}-vpc`, {
+        cidrBlock: args.vpcCidr,
+        enableDnsHostnames: true,
+        tags: args.tags,
+    }, { provider });
+
+    // Create subnets
+    const publicSubnets = args.publicSubnetCidrs.map((cidr, index) => 
+        new aws.ec2.Subnet(`${name}-public-${index}`, {
+            vpcId: vpc.id,
+            cidrBlock: cidr,
+            availabilityZone: args.azs[index],
+            mapPublicIpOnLaunch: true,
+            tags: { ...args.tags, Name: `${name}-public-${index}` },
+        }, { provider })
+    );
+
+    return { vpc, publicSubnets };
+}
+
+// File: index.ts
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import { createNetworking } from "./networking";
+import { createDatabase } from "./database";
+import { createInstances } from "./main";
+
+// Configuration (from variables.tf)
+const config = new pulumi.Config();
+const vpcCidr = config.get("vpcCidr") || "10.0.0.0/16";
+const environment = config.require("environment");
+
+// Provider setup (from providers.tf)
+const awsProvider = new aws.Provider("aws", {
+    region: config.get("awsRegion") || "us-west-2",
+});
+
+// Create resources
+const networking = createNetworking("app", {
+    vpcCidr,
+    publicSubnetCidrs: ["10.0.1.0/24", "10.0.2.0/24"],
+    azs: aws.getAvailabilityZones().then(azs => azs.names),
+    tags: { Environment: environment },
+}, awsProvider);
+
+// Outputs (from outputs.tf)
+export const vpcId = networking.vpc.id;
+export const publicSubnetIds = networking.publicSubnets.map(s => s.id);
+```
+
+For inline resources, add descriptive comments:
+```typescript
+// Create VPC
+const vpc = new aws.ec2.Vpc("main", {
+    cidrBlock: "10.0.0.0/16",
+    tags: {
+        Name: "main-vpc",
+    },
+}, { provider });
+
+// Create public subnet
+const publicSubnet = new aws.ec2.Subnet("public", {
+    vpcId: vpc.id,
+    cidrBlock: "10.0.1.0/24",
+    availabilityZone: "us-west-2a",
+    tags: {
+        Name: "public-subnet",
+    },
+}, { provider });
+```
+
+## Common Patterns Reference
+
+- Local values → `const` variables
+- Terraform functions → TypeScript/Pulumi equivalents:
+  - `concat()` → `[...array1, ...array2]` or `array1.concat(array2)`
+  - `merge()` → `{...obj1, ...obj2}`
+  - `lookup()` → `obj[key] ?? defaultValue`
+  - `length()` → `array.length`
+  - `element()` → `array[index]`
+  - `join()` → `array.join(separator)`
+  - `split()` → `string.split(separator)`
+
+## Enhanced Validation Methodology
+
+### Pre-Conversion Analysis
+Before starting conversion, perform these validation steps:
+
+1. **Resource Inventory**: Count and categorize all Terraform resources
+   ```bash
+   # Count resources by type
+   grep -h "^resource " *.tf | sort | uniq -c
+   # Count total resources
+   grep -h "^resource " *.tf | wc -l
+   ```
+
+2. **Complexity Assessment**: Use complexity framework above based on resource count and patterns
+
+3. **Provider Analysis**: Identify all required providers and versions
+   ```bash
+   grep -h "required_providers\|provider " *.tf
+   ```
+
+4. **Output Mapping**: List all expected outputs for validation
+   ```bash
+   grep -h "^output " *.tf | cut -d'"' -f2
+   ```
+
+### Baseline Evaluation
+⚠️ **CRITICAL**: Evaluate existing Pulumi examples before using as validation baseline:
+
+#### Red Flags for Incomplete Baselines
+- **Significantly fewer resources** than Terraform (>20% gap indicates incomplete conversion)
+- **Simplified component structure** vs full implementation
+- **Missing provider-specific patterns** (secrets management, identity, governance)
+- **Incomplete output structure** (missing critical exports)
+
+#### Baseline Quality Checklist
+```typescript
+// Use this checklist to evaluate existing examples:
+interface BaselineQuality {
+    resourceCount: {
+        terraform: number;
+        pulumi: number;
+        coveragePercent: number; // Should be >90%
+    };
+    outputCompleteness: {
+        terraformOutputs: string[];
+        pulumiExports: string[];
+        missingExports: string[];
+    };
+    componentArchitecture: {
+        hasProperComponents: boolean;
+        followsEnterprisePatterns: boolean;
+        hasCorrectInterfaces: boolean;
+    };
+}
+```
+
+### Validation Process
+
+#### 1. Primary Validation: Compare to Terraform Source
+```typescript
+// Validation should compare converted code to TERRAFORM source primarily
+const validationResult = {
+    resourceParity: "100%", // All TF resources have Pulumi equivalents
+    configurationAccuracy: "PASS", // Properties correctly mapped
+    outputCompleteness: "PASS", // All TF outputs exported
+    functionalParity: "PASS", // Same behavior expected
+};
+```
+
+#### 2. Secondary Validation: Baseline Comparison (If Applicable)
+```typescript
+// Only use existing examples if they pass baseline quality checks
+if (existingExample.passes.baselineQuality) {
+    compareWithExisting(convertedCode, existingExample);
+} else {
+    reportBaselineIssues(existingExample, terraformSource);
+    // Document what's wrong with existing example:
+    // - Missing features not in Terraform
+    // - Different API structure than Terraform
+    // - Incomplete resource coverage
+}
+```
+
+#### 3. Error Classification
+```typescript
+enum ValidationErrorType {
+    CRITICAL_MISSING_RESOURCE = "Missing resource from Terraform",
+    CRITICAL_WRONG_CONFIG = "Incorrect property mapping",
+    CRITICAL_MISSING_OUTPUT = "Missing required output",
+    ERROR_BASELINE_INCOMPLETE = "Baseline example missing TF features",
+    ERROR_BASELINE_EXTRA_FEATURES = "Baseline has features not in TF",
+    WARNING_STYLE_DIFFERENCE = "Different but functionally equivalent",
+    WARNING_API_VERSION_DIFF = "Different provider API version used"
+}
+```
+
+### Validation Reporting Format
+```markdown
+## Conversion Validation Report
+
+### Summary
+- **Terraform Resources**: 52
+- **Pulumi Resources**: 52
+- **Coverage**: 100%
+- **Status**: ✅ PASS / ⚠️ PASS WITH WARNINGS / ❌ FAIL
+
+### Resource Mapping
+✅ All 52 Terraform resources successfully mapped
+✅ All conditional logic preserved
+✅ All cross-resource dependencies maintained
+
+### Configuration Validation
+✅ All properties correctly mapped (snake_case → camelCase)
+✅ All variable defaults preserved
+✅ All provider configurations explicit
+
+### Output Validation
+✅ All 18 Terraform outputs exported (100% coverage)
+⚠️ Added 2 additional outputs for better component interfaces
+
+### Baseline Comparison Issues (If Applicable)
+❌ Existing example missing 21 resources (40% gap)
+❌ Existing example missing service principal management
+❌ Existing example missing policy assignments
+📋 Recommendation: Replace existing example with converted version
+```
+
+## Azure-Specific Best Practices
+
+### Naming Conventions
+```typescript
+// Follow Azure CAF (Cloud Adoption Framework) naming conventions
+interface AzureNamingConvention {
+    // Pattern: {resource-type}-{workload}-{environment}-{region}-{instance}
+    resourceGroup: string; // rg-myapp-prod-eus2-001
+    virtualNetwork: string; // vnet-myapp-prod-eus2-001
+    subnet: string; // snet-myapp-prod-eus2-web-001
+    networkSecurityGroup: string; // nsg-myapp-prod-eus2-web-001
+    keyVault: string; // kv-myapp-prod-eus2-001
+    storageAccount: string; // stmyappprodeus2001 (no dashes, max 24 chars)
+}
+
+// Implementation
+const locationShortCodes = {
+    "East US": "eus",
+    "East US 2": "eus2",
+    "West US 2": "wus2",
+    "Central US": "cus",
+    // ... other regions
+};
+
+function createResourceName(
+    resourceType: string,
+    workload: string,
+    environment: string,
+    location: string,
+    instance: string = "001"
+): string {
+    const locationShort = locationShortCodes[location] || "unk";
+    return `${resourceType}-${workload}-${environment}-${locationShort}-${instance}`;
+}
+```
+
+### Resource Tagging Strategy
+```typescript
+// Implement comprehensive tagging for governance
+interface EnterpriseTagStrategy {
+    // Required tags for all resources
+    required: {
+        Environment: string; // dev, staging, prod
+        CostCenter: string; // IT-Infrastructure, Marketing, etc.
+        Owner: string; // Team or individual responsible
+        Project: string; // Project or application name
+    };
+    // Optional but recommended tags
+    optional: {
+        CreatedBy: string; // Service principal or user
+        CreatedDate: string; // ISO timestamp
+        LastModified: string; // ISO timestamp
+        BackupPolicy: string; // None, Standard, Premium
+        MonitoringLevel: string; // Basic, Standard, Premium
+        ComplianceScope: string; // PCI, HIPAA, SOX, etc.
+    };
+}
+
+function createTagSet(
+    required: EnterpriseTagStrategy["required"],
+    optional?: Partial<EnterpriseTagStrategy["optional"]>
+): Record<string, string> {
+    return {
+        ...required,
+        ...optional,
+        ManagedBy: "pulumi",
+        CreatedDate: new Date().toISOString(),
+    };
+}
+```
+
+### RBAC Implementation Patterns
+```typescript
+// Enterprise RBAC patterns for Azure
+export class RBACManagementComponent extends BaseComponent {
+    constructor(name: string, args: RBACArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("custom:azure:RBACManagement", name, args, opts);
+        
+        // Built-in role definitions (never create custom unless absolutely necessary)
+        const builtInRoles = {
+            keyVaultAdministrator: "00482a5a-887f-4fb3-b363-3b7fe8e74483",
+            keyVaultSecretsOfficer: "b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
+            storageDataContributor: "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+            securityReader: "39bc4728-0917-49c7-9d2c-d95423bc2eb4",
+            contributor: "b24988ac-6180-42a0-ab88-20f7382dd24c",
+            reader: "acdd72a7-3385-48ef-bd42-f606fba81ae7",
+        };
+        
+        // Principle of least privilege assignments
+        this.assignRoles(args, builtInRoles);
+    }
+    
+    private assignRoles(args: RBACArgs, roles: Record<string, string>) {
+        // Use RBAC for Key Vault (preferred over access policies)
+        new azure.authorization.RoleAssignment("keyvault-admin", {
+            scope: args.keyVault.id,
+            roleDefinitionId: pulumi.interpolate`/subscriptions/${args.subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roles.keyVaultAdministrator}`,
+            principalId: args.deploymentPrincipalId,
+            principalType: azure.authorization.PrincipalType.User,
+        }, { parent: this });
+        
+        // Conditional assignments based on requirements
+        if (args.managedIdentity) {
+            new azure.authorization.RoleAssignment("mi-secrets-access", {
+                scope: args.keyVault.id,
+                roleDefinitionId: pulumi.interpolate`/subscriptions/${args.subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${roles.keyVaultSecretsOfficer}`,
+                principalId: args.managedIdentity.principalId,
+                principalType: azure.authorization.PrincipalType.ServicePrincipal,
+            }, { parent: this });
+        }
+    }
+}
+```
+
+## Project Setup and Compilation Verification
+
+After generating the TypeScript code, set up a proper Pulumi project structure and verify compilation. Make sure the project folder contains package.json, tsconfig.json, and Pulumi.yaml files.
+
+### Dependency Management
+Analyze the imports in the generated code and create appropriate package.json:
+
+**Step 1: Identify required packages from imports**
+```typescript
+import * as pulumi from "@pulumi/pulumi";      // Requires: @pulumi/pulumi
+import * as aws from "@pulumi/aws";            // Requires: @pulumi/aws
+import * as awsx from "@pulumi/awsx";          // Requires: @pulumi/awsx
+// etc.
+```
+
+**Step 2: Generate package.json with discovered dependencies**
+```json
+{
+  "name": "tf-to-pulumi-conversion",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^18",
+    "typescript": "^5.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/aws": "^6.0.0"  // Add ALL packages found in imports
+  }
+}
+```
+
+**Step 3: Install dependencies**
+```bash
+npm install
+```
+
+### Enhanced Compilation Verification
+
+#### Multi-Stage Compilation Testing
+```bash
+# Stage 1: Syntax and type checking
+npm install
+npx tsc --noEmit
+
+# Stage 2: Pulumi-specific validation
+pulumi preview --diff  # Validate resource definitions without deployment
+```
+
+### 5. Common Compilation Issues and Fixes
+
+#### Type Errors
+```typescript
+// Issue: Output type not handled correctly
+❌ const name = resource.name + "-suffix";
+✅ const name = resource.name.apply(n => `${n}-suffix`);
+
+// Issue: Missing type annotations
+❌ const config = new pulumi.Config();
+❌ const value = config.get("key");
+✅ const config = new pulumi.Config();
+✅ const value: string = config.get("key") || "default";
+
+// Issue: Incorrect Input/Output usage
+❌ function createResource(name: string): Resource
+✅ function createResource(name: pulumi.Input<string>): Resource
+```
+
+#### Import Issues
+```typescript
+// Issue: Missing provider imports based on usage
+❌ import * as pulumi from "@pulumi/pulumi";
+❌ // Using azure.resources.ResourceGroup but no import
+
+✅ import * as pulumi from "@pulumi/pulumi";
+✅ import * as azure from "@pulumi/azure-native";
+✅ import * as azuread from "@pulumi/azuread";  // If using Azure AD
+✅ import * as random from "@pulumi/random";   // If using random resources
+```
+
+#### Property Name Issues
+```typescript
+// Issue: Snake case from Terraform not converted
+❌ new azure.storage.StorageAccount("storage", {
+❌     account_tier: "Standard",                    // Should be accountTier
+❌     account_replication_type: "LRS",             // Should be accountReplicationType
+❌ });
+
+✅ new azure.storage.StorageAccount("storage", {
+✅     accountTier: "Standard",
+✅     accountReplicationType: "LRS",
+✅ });
+```
+
+#### Component Interface Issues
+```typescript
+// Issue: Missing required properties in interfaces
+❌ export interface ComponentArgs {
+❌     name?: string;  // Optional when should be required
+❌ }
+
+✅ export interface ComponentArgs {
+✅     namingPrefix: pulumi.Input<string>;          // Required
+✅     commonTags: {[key: string]: pulumi.Input<string>}; // Required
+✅     resourceGroups: {                            // Required structure
+✅         main: azure.resources.ResourceGroup;
+✅     };
+✅     optionalFeature?: boolean;                   // Truly optional
+✅ }
+```
+
+## Pre-Conversion Validation Checklist
+
+Before starting conversion, verify these patterns to prevent common errors:
+
+### 1. Resource Completeness Check
+- [ ] List ALL resources in Terraform (including "obvious" ones like namespaces)
+- [ ] Identify prerequisite resources (namespaces, providers, CRDs)
+- [ ] Check for implicit dependencies that need explicit creation
+- [ ] Verify no resources are skipped in conversion
+
+### 2. Configuration Safety Check
+- [ ] Identify all configuration objects and their types
+- [ ] Plan safe access patterns for optional/missing keys
+- [ ] Design fallback values for all configuration access
+- [ ] Add null checking for dynamic object access
+
+### 3. Label and Metadata Check
+- [ ] Identify all `managed-by` labels in Terraform
+- [ ] Plan label conversions (terraform → pulumi)
+- [ ] Preserve all business logic labels exactly
+- [ ] Add appropriate Pulumi-specific labels
+
+### 4. Secret and Sensitive Data Check
+- [ ] Identify all secret resources and their encoding
+- [ ] Plan `stringData` usage over manual base64 encoding
+- [ ] Design safe Output handling for secret values
+- [ ] Verify sensitive data is properly marked
+
+## Your Task
+
+Convert the following Terraform configuration to Pulumi TypeScript. You MUST:
+1. **IMPORTANT**: Generate the converted TypeScript code in the folder specified by user request. If none is specified, create a folder named `pulumi`.
+2. Create all necessary project files in the same folder
+3. **Run `npm install` and `npx tsc --noEmit` to verify compilation**
+4. Initialize a Pulumi stack with `pulumi stack init dev`.
+5. **Run `pulumi preview` to validate Pulumi resources**
+6. Fix any compilation or preview errors before considering the task complete
+
+Your output should include:
+
+### 1. The Converted TypeScript Code (index.ts)
+- All resources accurately translated
+- TypeScript best practices followed
+- Strong typing used throughout
+- Idiomatic and maintainable code
+- All functionality preserved
+- **Provider blocks explicitly converted** (not implicit)
+- **ALL Terraform outputs converted to exports**
+- **Resource comments preserved** for documentation
+- Variable names matching Terraform resource names for easier migration (except for generic names like "this" which should be made descriptive)
+
+### 2. Project Configuration Files
+Generate the necessary files for a compilable Pulumi TypeScript project:
+
+**package.json** - Include all required Pulumi packages based on the imports used:
+```json
+{
+  "name": "terraform-to-pulumi-conversion",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^18",
+    "typescript": "^5.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0",
+    // Add other @pulumi/* packages based on imports
+  }
+}
+```
+
+**tsconfig.json** - TypeScript configuration:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "bin"
+  },
+  "include": ["*.ts"]
+}
+```
+
+**Pulumi.yaml** - Basic Pulumi project file:
+```yaml
+name: terraform-conversion
+runtime: nodejs
+description: Converted from Terraform
+```
+
+### 3. Compilation and Preview Verification (REQUIRED)
+**IMPORTANT**: You MUST run both TypeScript compilation and Pulumi validation to verify your conversion.
+
+If compilation errors occur:
+1. Fix all type errors
+2. Ensure all imports are correct
+3. Verify property names use camelCase
+4. Add any missing required properties
+5. Re-run `npm test` until no errors remain
+
+If Pulumi preview errors occur:
+1. Check resource property mappings
+2. Verify provider configurations
+3. Ensure Output types are handled correctly
+4. Fix any resource dependency issues
+5. Re-run the preview script until no errors remain
+
+**DO NOT** consider the conversion complete until both compilation and preview are successful.

--- a/src/prompts/prompts.ts
+++ b/src/prompts/prompts.ts
@@ -1,0 +1,40 @@
+import { logger } from '../logging/logging.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Get the directory of the current module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Function to read prompt from local markdown file
+export async function getPrompt(promptName: string, type: string): Promise<string> {
+  // Construct path to the markdown file in same directory as the bundled JS
+  const promptPath = path.join(__dirname, `${promptName}.md`);
+
+  logger.info(`Reading prompt from: ${promptPath}`);
+
+  try {
+    const promptContent = await fs.promises.readFile(promptPath, 'utf-8');
+    logger.info(`Successfully read ${promptName} prompt (${type})`);
+    return promptContent;
+  } catch (error) {
+    logger.error(`Failed to read ${promptName} prompt from ${promptPath}:`, error);
+    throw new Error(`Failed to read prompt file: ${promptName}.md`);
+  }
+}
+
+export async function promptHandler(promptName: string) {
+  const promptText = await getPrompt(promptName, 'prompt');
+  return {
+    messages: [
+      {
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: promptText
+        }
+      }
+    ]
+  };
+}

--- a/src/pulumi/convert.ts
+++ b/src/pulumi/convert.ts
@@ -1,0 +1,9 @@
+import { promptHandler } from '../prompts/prompts.js';
+
+export const convertPrompts = {
+  'convert-terraform-to-typescript': {
+    name: 'convert-terraform-to-typescript',
+    description: 'Convert a Terraform program to a Pulumi TypeScript program',
+    handler: () => promptHandler('convert-terraform-to-typescript')
+  }
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { cliCommands } from '../pulumi/cli.js';
 import { logger } from '../logging/logging.js';
 import { deployCommands, deployPrompts } from '../deploy/deploy.js';
+import { convertPrompts } from '../pulumi/convert.js';
 
 // Get the directory of the current module
 const __filename = fileURLToPath(import.meta.url);
@@ -90,7 +91,19 @@ export class Server extends McpServer {
 
     // Register deploy prompts
     Object.entries(deployPrompts).forEach(([promptName, prompt]) => {
-      this.prompt(promptName, prompt.description, {}, async () => {
+      this.prompt(promptName, prompt.description, async () => {
+        try {
+          return await prompt.handler();
+        } catch (error) {
+          logger.error(`Error in prompt ${promptName}:`, error);
+          throw error;
+        }
+      });
+    });
+
+    // Register convert prompts
+    Object.entries(convertPrompts).forEach(([promptName, prompt]) => {
+      this.prompt(promptName, prompt.description, async () => {
         try {
           return await prompt.handler();
         } catch (error) {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,65 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface InspectorTool {
+  name: string;
+  description: string;
+  inputSchema: object;
+}
+
+export interface InspectorPrompt {
+  name: string;
+  description: string;
+  arguments: object;
+}
+
+export interface InspectorTextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ListToolsResponse {
+  tools: InspectorTool[];
+}
+
+export interface ListPromptsResponse {
+  prompts: InspectorPrompt[];
+}
+
+export interface ToolCallResponse {
+  content: InspectorTextContent[];
+}
+
+async function runInspectorCommand<T>(command: string): Promise<T> {
+  const inspectorCommand = `npx @modelcontextprotocol/inspector --cli node dist/index.js stdio ${command}`;
+  try {
+    const { stdout } = await execAsync(inspectorCommand);
+    return JSON.parse(stdout) as T;
+  } catch (error) {
+    if (error instanceof Error && 'stdout' in error) {
+      console.error('Command stdout:', error.stdout);
+      if ('stderr' in error) {
+        console.error('Command stderr:', error.stderr);
+      }
+    }
+    throw error;
+  }
+}
+
+export function listTools(): Promise<ListToolsResponse> {
+  return runInspectorCommand<ListToolsResponse>('--method tools/list');
+}
+
+export function listPrompts(): Promise<ListPromptsResponse> {
+  return runInspectorCommand<ListPromptsResponse>('--method prompts/list');
+}
+
+export function callTool(toolName: string, args?: string): Promise<ToolCallResponse> {
+  let command = `--method tools/call --tool-name ${toolName}`;
+  if (args) {
+    command += ` ${args}`;
+  }
+  return runInspectorCommand<ToolCallResponse>(command);
+}

--- a/test/mcp-convert.test.ts
+++ b/test/mcp-convert.test.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from 'chai';
+import { listPrompts } from './helpers.js';
+
+describe('MCP Prompt: convert', () => {
+  describe('Prompt Metadata', () => {
+    it('should list convert-terraform-to-typescript as an available prompt', async function () {
+      const response = await listPrompts();
+
+      const convertPrompt = response.prompts.find(
+        (prompt) => prompt.name === 'convert-terraform-to-typescript'
+      );
+      expect(convertPrompt).to.not.equal(undefined);
+      expect(convertPrompt?.name).to.equal('convert-terraform-to-typescript');
+      expect(convertPrompt?.description).to.contain('Terraform');
+    });
+  });
+});


### PR DESCRIPTION
Adds a prompt to convert a Terraform project to a Pulumi TypeScript project. The prompt itself is mostly copied from https://github.com/pulumi/tf-to-pulumi-prompts/blob/main/prompts/convert_typescript.md but I simplified it a bit (e.g. removed the fake preview script reference). It works for a test project that I applied it:

```
    ☒ Create pulumi directory for converted project          
     ☒ Convert main.tf to index.ts with random_string resource
     ☒ Create package.json with @pulumi/random dependency
     ☒ Create tsconfig.json for TypeScript configuration
     ☒ Create Pulumi.yaml project file
     ☒ Run npm install to install dependencies
     ☒ Run TypeScript compilation check
     ☒ Initialize Pulumi stack
     ☒ Run pulumi preview to validate resources
```

I refactored a bit of Deploy to AWS code to reuse the same blocks and not duplicate too much stuff. Also tried to fix all linter errors that I found.

The next steps are:

1. Once it's merged, we'll start testing the prompt of TF convert benchmarks that we are building.
2. Separately, I'll open a PR for a tool that may use `pulumi convert` in combination with the prompts. Then we'll be able to compare it with separate `pulumi convert` and prompt-only conversions.