### PR TITLE
Add Claude API integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.54.0",
         "@modelcontextprotocol/sdk": "^1.11.1",
         "@pulumi/pulumi": "^3.169.0",
         "express": "^5.1.0",
@@ -36,6 +37,15 @@
         "tsup": "^8.4.0",
         "typescript": "^5.3.0",
         "typescript-eslint": "^8.32.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.54.0.tgz",
+      "integrity": "sha512-xyoCtHJnt/qg5GG6IgK+UJEndz8h8ljzt/caKXmq3LfBF81nC/BW6E4x2rOWCZcvsLyVW+e8U5mtIr6UCE/kJw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -31,32 +31,35 @@
     "build:watch": "tsup --watch",
     "test": "NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 'test/**/*.test.ts'",
     "test:watch": "NODE_OPTIONS='--loader ts-node/esm' mocha --watch --watch-files test 'test/**/*.test.ts'",
+    "test:unit": "NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 --grep '^(?!.*Claude API Integration)' 'test/**/*.test.ts'",
+    "test:integration": "NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 --grep 'Claude API Integration' 'test/**/*.test.ts'",
     "inspector": " npx @modelcontextprotocol/inspector dist/index.js"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.54.0",
     "@modelcontextprotocol/sdk": "^1.11.1",
     "@pulumi/pulumi": "^3.169.0",
     "express": "^5.1.0",
     "pino": "^9.6.0",
-    "zod": "^3.24.4",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
+    "@eslint/js": "^9.26.0",
     "@types/chai": "^4.3.11",
-    "@types/mocha": "^10.0.6",
     "@types/express": "^5.0.1",
+    "@types/mocha": "^10.0.6",
     "@types/node": "^22.14.1",
     "@types/yargs": "^17.0.33",
     "chai": "^5.1.0",
-    "mocha": "^10.3.0",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.3.0",
     "eslint": "^9.26.0",
-    "tsup": "^8.4.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.0",
+    "mocha": "^10.3.0",
     "prettier": "^3.5.3",
-    "@eslint/js": "^9.26.0",
+    "ts-node": "^10.9.2",
+    "tsup": "^8.4.0",
+    "typescript": "^5.3.0",
     "typescript-eslint": "^8.32.0"
   }
 }

--- a/test/claude-api-integration.test.ts
+++ b/test/claude-api-integration.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from 'chai';
+import { testToolInvocation, ToolInvocationTest } from './helpers.js';
+
+describe('Claude API Integration - Natural Language to Tool Mapping', function () {
+  before(function () {
+    console.log('ANTHROPIC_API_KEY present:', !!process.env.ANTHROPIC_API_KEY);
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.log('Skipping Claude API integration tests - no API key');
+      this.skip();
+    }
+  });
+
+  describe('Deploy to AWS Tool Mapping', () => {
+    const deployTestCases: ToolInvocationTest[] = [
+      {
+        query: 'Deploy this code to AWS',
+        expectedTool: 'deploy-to-aws',
+        description: 'Direct deployment request',
+        contextType: 'nodejs'
+      },
+      {
+        query: 'I want to deploy my application to Amazon Web Services',
+        expectedTool: 'deploy-to-aws',
+        description: 'Verbose deployment request',
+        contextType: 'nodejs'
+      },
+      {
+        query: 'Can you help me get this running on AWS?',
+        expectedTool: 'deploy-to-aws',
+        description: 'Casual deployment request',
+        contextType: 'nodejs'
+      },
+      {
+        query: 'Set up my app in the cloud using AWS',
+        expectedTool: 'deploy-to-aws',
+        description: 'Cloud setup request',
+        contextType: 'nodejs'
+      }
+    ];
+
+    deployTestCases.forEach((testCase) => {
+      it(`should invoke deploy-to-aws tool for: "${testCase.description}"`, async function () {
+        const toolInvoked = await testToolInvocation(testCase);
+        expect(toolInvoked).to.equal(testCase.expectedTool);
+      });
+    });
+
+    // TODO: Fix tool selection specificity - currently deploy-to-aws is incorrectly invoked for Azure requests
+    // Negative test - should NOT invoke deploy-to-aws for Azure
+    it.skip('should NOT invoke deploy-to-aws tool for Azure deployment', async function () {
+      const toolInvoked = await testToolInvocation({
+        query: 'Deploy this code to Azure',
+        expectedTool: 'should-not-invoke-any-tool',
+        description: 'Azure deployment request',
+        contextType: 'nodejs'
+      });
+
+      // Show what tool was actually invoked
+      console.log('Tool invoked for Azure deployment:', toolInvoked);
+
+      // This test should fail - we expect Claude to NOT invoke deploy-to-aws for Azure
+      expect(toolInvoked).to.not.equal(
+        'deploy-to-aws',
+        `Claude incorrectly invoked deploy-to-aws for Azure deployment. This shows the tool selection is too broad.`
+      );
+    });
+  });
+
+  describe('Pulumi Registry Tool Mapping', () => {
+    const registryTestCases: ToolInvocationTest[] = [
+      {
+        query: 'Show me information about AWS S3 bucket resource',
+        expectedTool: 'pulumi-registry-get-resource',
+        description: 'Resource information request',
+        contextType: 'none'
+      },
+      {
+        query: 'What are the available resources for AWS EC2?',
+        expectedTool: 'pulumi-registry-list-resources',
+        description: 'List resources request',
+        contextType: 'none'
+      },
+      {
+        query: 'Get details about the Lambda function resource in AWS',
+        expectedTool: 'pulumi-registry-get-resource',
+        description: 'Specific resource details',
+        contextType: 'none'
+      }
+    ];
+
+    registryTestCases.forEach((testCase) => {
+      it(`should invoke ${testCase.expectedTool} tool for: "${testCase.description}"`, async function () {
+        const toolInvoked = await testToolInvocation(testCase);
+        expect(toolInvoked).to.equal(testCase.expectedTool);
+      });
+    });
+  });
+
+  describe('Pulumi CLI Tool Mapping', () => {
+    const cliTestCases: ToolInvocationTest[] = [
+      {
+        query: 'Run pulumi preview to see what changes will be made',
+        expectedTool: 'pulumi-cli-preview',
+        description: 'Preview command request',
+        contextType: 'pulumi'
+      },
+      {
+        query: 'Deploy my Pulumi stack',
+        expectedTool: 'pulumi-cli-up',
+        description: 'Stack deployment request',
+        contextType: 'pulumi'
+      },
+      {
+        query: 'Show me the outputs from my Pulumi stack',
+        expectedTool: 'pulumi-cli-stack-output',
+        description: 'Stack output request',
+        contextType: 'pulumi'
+      },
+      {
+        query: 'Refresh my Pulumi stack state',
+        expectedTool: 'pulumi-cli-refresh',
+        description: 'Stack refresh request',
+        contextType: 'pulumi'
+      }
+    ];
+
+    cliTestCases.forEach((testCase) => {
+      it(`should invoke ${testCase.expectedTool} tool for: "${testCase.description}"`, async function () {
+        const toolInvoked = await testToolInvocation(testCase);
+        expect(toolInvoked).to.equal(testCase.expectedTool);
+      });
+    });
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { Anthropic } from '@anthropic-ai/sdk';
 
 const execAsync = promisify(exec);
 
@@ -62,4 +63,122 @@ export function callTool(toolName: string, args?: string): Promise<ToolCallRespo
     command += ` ${args}`;
   }
   return runInspectorCommand<ToolCallResponse>(command);
+}
+
+// Claude API integration testing interfaces
+
+export interface ToolInvocationTest {
+  query: string;
+  expectedTool: string;
+  description: string;
+  contextType?: 'nodejs' | 'pulumi' | 'none';
+}
+
+// Helper to create realistic project context based on explicit context type
+function getProjectContext(contextType?: string): string {
+  switch (contextType) {
+    case 'nodejs':
+      return `I have a Node.js web application with the following structure:
+
+package.json:
+{
+  "name": "my-web-app",
+  "version": "1.0.0",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^4.18.0"
+  }
+}
+
+app.js:
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('Hello World!');
+});
+
+app.listen(port, () => {
+  console.log(\`Server running on port \${port}\`);
+});`;
+
+    case 'pulumi':
+      return `I have a Pulumi project in the current directory (/my-project) with the following files:
+
+Pulumi.yaml:
+name: my-infrastructure
+runtime: nodejs
+
+index.ts:
+import * as aws from "@pulumi/aws";
+
+const bucket = new aws.s3.Bucket("my-bucket");
+export const bucketName = bucket.id;`;
+
+    case 'none':
+    default:
+      return `I have a development environment set up and ready.`;
+  }
+}
+
+// Claude API testing function
+export async function testToolInvocation(testCase: ToolInvocationTest): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY environment variable is required for Claude API testing');
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  // Create a realistic project context based on explicit context type
+  const contextMessage = getProjectContext(testCase.contextType);
+
+  const messages = [
+    {
+      role: 'user' as const,
+      content: contextMessage
+    },
+    {
+      role: 'user' as const,
+      content: testCase.query
+    }
+  ];
+
+  // Create a message that includes MCP server configuration
+  // This mimics the behavior of the MCP client when it invokes tools
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 1000,
+    messages,
+    tools: await getMCPTools() // Get available tools from our MCP server
+  });
+
+  // Check if a tool was invoked
+  const toolUseContent = response.content.find((item: any) => item.type === 'tool_use');
+
+  if (toolUseContent && 'name' in toolUseContent) {
+    return (toolUseContent as any).name;
+  } else {
+    throw new Error(`No tool was invoked for query: "${testCase.query}"`);
+  }
+}
+
+// Helper to get MCP tools in Anthropic API format
+async function getMCPTools(): Promise<any[]> {
+  try {
+    const toolsResponse = await listTools();
+
+    return toolsResponse.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: tool.inputSchema as any
+    }));
+  } catch (error) {
+    console.error('Failed to get MCP tools:', error);
+    return [];
+  }
 }


### PR DESCRIPTION
Introduces integration tests that ensure that the expected user queries invoke the right tools. This mimics tool selection behavior of MCP clients.

Requires ANTHROPIC_API_KEY.