### PR TITLE
Tighten the registry command execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pulumi/mcp-server",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pulumi/mcp-server",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-code": "^1.0.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulumi/mcp-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A server implementing the Model Context Protocol for Pulumi.",
   "author": "Pulumi Corporation",
   "license": "Apache-2.0",

--- a/src/pulumi/registry.ts
+++ b/src/pulumi/registry.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 // Define schema types
 type ResourceProperty = {
@@ -103,7 +103,8 @@ export const registryCommands = function (cacheDir: string) {
     );
 
     if (!fs.existsSync(cacheFile)) {
-      execSync(`pulumi package get-schema ${providerWithVersion} >> ${cacheFile}`);
+      const output = execFileSync('pulumi', ['package', 'get-schema', providerWithVersion]);
+      fs.writeFileSync(cacheFile, output);
     }
     return JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -79,7 +79,6 @@ export class Server extends McpServer {
     // Register deploy commands
     Object.entries(deployCommands).forEach(([commandName, command]) => {
       const toolName = commandName;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.tool(toolName, command.description, command.schema, async () => {
         try {
           return await command.handler();


### PR DESCRIPTION
Tighten the registry tools to use `execFileSync ` instead of `execSync`.

ESLint comment is unrelated but was failing my `npm run lint`.