### PR TITLE
Fix requiredOutputs list for registry resources

### DIFF
--- a/src/pulumi/registry.ts
+++ b/src/pulumi/registry.ts
@@ -223,6 +223,10 @@ export const registryCommands = function (cacheDir: string) {
                 outputProperties[key] = value;
               }
             }
+            const requiredOutputs = schema.required.filter(
+              (name) => !(name in schema.inputProperties)
+            );
+
             return {
               // for now leaving out:
               // - `description`: Can be pretty large and contains all language examples (if we knew the language we could extract the specific language example)
@@ -230,7 +234,7 @@ export const registryCommands = function (cacheDir: string) {
               requiredInputs: schema.requiredInputs,
               inputProperties: schema.inputProperties,
               outputProperties: outputProperties,
-              requiredOutputs: schema.required
+              requiredOutputs: requiredOutputs
             };
           });
           return {


### PR DESCRIPTION
## Summary
- compute `requiredOutputs` correctly in registry resources

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672ca793f0832fa14393b6bb89fe8c