### PR TITLE
Fix typo in AWS deployment guide

### DIFF
--- a/src/prompts/deploy-to-aws.md
+++ b/src/prompts/deploy-to-aws.md
@@ -41,7 +41,7 @@ When a user requests infrastructure deployment assistance:
    - Implement security hardening by default
 
 5. **Verification of result**
-   - Afther the infrastructure code has been generated, verify it by running `pulumi preview`. You will need to run the following commands:
+   - After the infrastructure code has been generated, verify it by running `pulumi preview`. You will need to run the following commands:
      - Install the necessary packages. For example, here is how to do this for Node.js packages:
      ```bash
      cd infrastructure


### PR DESCRIPTION
## Summary
- fix small spelling typo in deploy-to-aws docs

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672df18a28832f929e15389137c347