### PR TITLE
Add Pulumi resource search tool and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "dev": "tsx watch src/index.ts stdio",
     "build": "tsup",
     "build:watch": "tsup --watch",
-    "test": "NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 'test/**/*.test.ts'",
+    "test": "MCP_TEST_MODE=true NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 'test/**/*.test.ts'",
     "test:watch": "NODE_OPTIONS='--loader ts-node/esm' mocha --watch --watch-files test 'test/**/*.test.ts'",
-    "test:unit": "NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 --grep '^(?!.*Claude Code SDK)' 'test/**/*.test.ts'",
+    "test:unit": "MCP_TEST_MODE=true NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 30000 --grep '^(?!.*Claude Code SDK)' 'test/**/*.test.ts'",
     "test:claude-code": "NODE_OPTIONS='--loader ts-node/esm' mocha --timeout 60000 --grep 'Claude Code SDK' 'test/**/*.test.ts'",
     "inspector": "./node_modules/.bin/mcp-inspector-cli --cli node dist/index.js stdio"
   },

--- a/src/insights/pulumi-api-client.ts
+++ b/src/insights/pulumi-api-client.ts
@@ -162,11 +162,13 @@ export class MockPulumiApiClient extends PulumiSearchApiClient {
             type: 'aws:s3:Bucket',
             project: 'example-project',
             stack: 'dev',
-            properties: request.properties ? {
-              bucket: 'acme-bucket',
-              region: 'us-west-2'
-              // No tags property = untagged
-            } : {},
+            properties: request.properties
+              ? {
+                  bucket: 'acme-bucket',
+                  region: 'us-west-2'
+                  // No tags property = untagged
+                }
+              : {},
             id: 'arn:aws:s3:::acme-bucket',
             created: '2024-01-15T10:30:00Z',
             modified: '2024-01-15T10:30:00Z',
@@ -192,10 +194,12 @@ export class MockPulumiApiClient extends PulumiSearchApiClient {
           type: 'aws:ec2:Instance',
           project: 'example-project',
           stack: 'dev',
-          properties: request.properties ? {
-            instanceType: 't3.micro',
-            tags: { Environment: 'dev' }
-          } : {},
+          properties: request.properties
+            ? {
+                instanceType: 't3.micro',
+                tags: { Environment: 'dev' }
+              }
+            : {},
           id: 'i-1234567890abcdef0',
           created: '2024-01-15T10:30:00Z',
           modified: '2024-01-15T10:30:00Z',

--- a/src/insights/pulumi-api-client.ts
+++ b/src/insights/pulumi-api-client.ts
@@ -1,0 +1,215 @@
+/**
+ * Pulumi API Client for resource search
+ * This module handles actual API calls to Pulumi Cloud Service
+ */
+
+export interface PulumiSearchRequest {
+  query: string;
+  org: string;
+  size?: number;
+  page?: number;
+  top?: number;
+  properties?: boolean;
+  source?: string;
+  facet?: string[];
+  ai?: string;
+}
+
+export interface PulumiSearchResponse {
+  resources: {
+    name: string;
+    type: string;
+    project: string;
+    stack: string;
+    properties: Record<string, unknown>;
+    id?: string;
+    created?: string;
+    modified?: string;
+    provider?: string;
+    package?: string;
+  }[];
+  facets: {
+    type: { [key: string]: number };
+    package: { [key: string]: number };
+    project: { [key: string]: number };
+    stack: { [key: string]: number };
+  };
+  totalResources: number;
+  page?: number;
+  size?: number;
+}
+
+export interface PulumiSearchApiClientConfig {
+  apiUrl: string;
+  accessToken: string;
+  timeout?: number;
+}
+
+/**
+ * Client for interacting with Pulumi Cloud Resource Search API
+ */
+export class PulumiSearchApiClient {
+  constructor(private config: PulumiSearchApiClientConfig) {}
+
+  /**
+   * Search for resources using Pulumi Cloud Resource Search API
+   * Calls: GET /api/orgs/{orgName}/search/resources
+   */
+  async searchResources(request: PulumiSearchRequest): Promise<PulumiSearchResponse> {
+    const url = new URL(`/api/orgs/${request.org}/search/resources`, this.config.apiUrl);
+
+    // Add query parameters
+    url.searchParams.set('query', request.query);
+    url.searchParams.set('size', (request.size || 25).toString());
+    url.searchParams.set('page', (request.page || 0).toString());
+    url.searchParams.set('top', (request.top || 20).toString());
+    url.searchParams.set('properties', (request.properties || false).toString());
+    url.searchParams.set('source', request.source || 'mcp-server');
+
+    // Add facet parameters
+    const facets = request.facet || ['type', 'package', 'project', 'stack'];
+    facets.forEach((facet) => {
+      url.searchParams.append('facet', facet);
+    });
+
+    if (request.ai) {
+      url.searchParams.set('ai', request.ai);
+    }
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Authorization: `token ${this.config.accessToken}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'pulumi-mcp-server'
+      },
+      signal: AbortSignal.timeout(this.config.timeout || 30000)
+    });
+
+    if (!response.ok) {
+      if (response.status === 402) {
+        throw new Error('Quota limit exceeded for resource search API');
+      }
+      if (response.status === 401) {
+        throw new Error('Unauthorized: Invalid or expired access token');
+      }
+      if (response.status === 403) {
+        throw new Error('Forbidden: Insufficient permissions for resource search');
+      }
+      if (response.status === 404) {
+        throw new Error(`Organization '${request.org}' not found`);
+      }
+
+      throw new Error(`Pulumi API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    // Transform the API response to match our interface
+    return {
+      resources: data.resources || [],
+      facets: data.facets || {
+        type: {},
+        package: {},
+        project: {},
+        stack: {}
+      },
+      totalResources: data.total || 0,
+      page: data.page,
+      size: data.size
+    };
+  }
+}
+
+/**
+ * Factory function to create PulumiApiClient with environment-based configuration
+ */
+export function createPulumiSearchApiClient(): PulumiSearchApiClient {
+  const apiUrl = process.env.PULUMI_API_URL || 'https://api.pulumi.com';
+  const accessToken = process.env.PULUMI_ACCESS_TOKEN;
+
+  if (!accessToken) {
+    throw new Error('PULUMI_ACCESS_TOKEN environment variable is required');
+  }
+
+  return new PulumiSearchApiClient({
+    apiUrl,
+    accessToken,
+    timeout: 30000
+  });
+}
+
+/**
+ * Mock client for testing - returns stub data without making real API calls
+ */
+export class MockPulumiApiClient extends PulumiSearchApiClient {
+  constructor() {
+    super({ apiUrl: 'http://mock', accessToken: 'mock' });
+  }
+
+  async searchResources(request: PulumiSearchRequest): Promise<PulumiSearchResponse> {
+    // Simulate network delay
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const lowerQuery = request.query.toLowerCase();
+
+    // Return different mock data based on query
+    if (lowerQuery.includes('type:aws:s3:bucket') && lowerQuery.includes('-properties.tags:')) {
+      return {
+        resources: [
+          {
+            name: 'acme-bucket',
+            type: 'aws:s3:Bucket',
+            project: 'example-project',
+            stack: 'dev',
+            properties: {
+              bucket: 'acme-bucket',
+              region: 'us-west-2'
+              // No tags property = untagged
+            },
+            id: 'arn:aws:s3:::acme-bucket',
+            created: '2024-01-15T10:30:00Z',
+            modified: '2024-01-15T10:30:00Z',
+            provider: 'aws',
+            package: 'aws'
+          }
+        ],
+        facets: {
+          type: { 'aws:s3:Bucket': 1 },
+          package: { aws: 1 },
+          project: { 'example-project': 1 },
+          stack: { dev: 1 }
+        },
+        totalResources: 1
+      };
+    }
+
+    // Default mock response
+    return {
+      resources: [
+        {
+          name: 'example-resource',
+          type: 'aws:ec2:Instance',
+          project: 'example-project',
+          stack: 'dev',
+          properties: {
+            instanceType: 't3.micro',
+            tags: { Environment: 'dev' }
+          },
+          id: 'i-1234567890abcdef0',
+          created: '2024-01-15T10:30:00Z',
+          modified: '2024-01-15T10:30:00Z',
+          provider: 'aws',
+          package: 'aws'
+        }
+      ],
+      facets: {
+        type: { 'aws:ec2:Instance': 1 },
+        package: { aws: 1 },
+        project: { 'example-project': 1 },
+        stack: { dev: 1 }
+      },
+      totalResources: 1
+    };
+  }
+}

--- a/src/insights/resource-search.ts
+++ b/src/insights/resource-search.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { MockPulumiApiClient, createPulumiSearchApiClient } from './pulumi-api-client.js';
-import * as automation from '@pulumi/pulumi/automation/index.js';
 
 export type ResourceSearchArgs = {
   query: string;
@@ -68,10 +67,7 @@ export const resourceSearchCommands = {
         .number()
         .optional()
         .describe('Maximum number of top results to return (defaults to 20)'),
-      size: z
-        .number()
-        .optional()
-        .describe('Number of results per page (defaults to 25)')
+      size: z.number().optional().describe('Number of results per page (defaults to 25)')
     },
     handler: async (args: ResourceSearchArgs) => {
       const isTestMode = process.env.MCP_TEST_MODE === 'true';
@@ -79,7 +75,7 @@ export const resourceSearchCommands = {
       if (isTestMode) {
         // Get org - use provided org or mock default for testing
         const org = args.org || 'mock-org';
-        
+
         // Use mock client for testing
         const mockClient = new MockPulumiApiClient();
         const mockResponse = await mockClient.searchResources({
@@ -123,8 +119,8 @@ export const resourceSearchCommands = {
         };
       } else {
         // Get org - use provided org or detect default org
-        const org = args.org || await getDefaultOrg();
-        
+        const org = args.org || (await getDefaultOrg());
+
         // Use real API client - will throw clear error if token is missing
         const apiClient = createPulumiSearchApiClient();
         const apiResponse = await apiClient.searchResources({

--- a/src/insights/resource-search.ts
+++ b/src/insights/resource-search.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+import { MockPulumiApiClient, createPulumiSearchApiClient } from './pulumi-api-client.js';
+import * as automation from '@pulumi/pulumi/automation/index.js';
+
+export type ResourceSearchArgs = {
+  query: string;
+  org?: string;
+  top?: number;
+  size?: number;
+};
+
+export type ResourceSearchResult = {
+  query: string;
+  resources: {
+    name: string;
+    type: string;
+    project: string;
+    stack: string;
+    properties: Record<string, unknown>;
+  }[];
+  summary: string;
+  facets?: {
+    type: { [key: string]: number };
+    package: { [key: string]: number };
+    project: { [key: string]: number };
+    stack: { [key: string]: number };
+  };
+  totalResources: number;
+};
+
+async function getDefaultOrg(): Promise<string> {
+  try {
+    // Use shell execution to run 'pulumi org get-default' directly
+    const { exec } = await import('child_process');
+    const { promisify } = await import('util');
+    const execAsync = promisify(exec);
+
+    const { stdout } = await execAsync('pulumi org get-default');
+    const defaultOrg = stdout.trim();
+
+    if (!defaultOrg) {
+      throw new Error('No default organization set');
+    }
+
+    return defaultOrg;
+  } catch (error) {
+    throw new Error(
+      `Could not determine Pulumi default organization. Please specify 'org' parameter. Error: ${error}`
+    );
+  }
+}
+
+export const resourceSearchCommands = {
+  'resource-search': {
+    description:
+      'Search and analyze Pulumi-managed cloud resources using Lucene-style queries. This tool can discover, count, and analyze your deployed infrastructure across all cloud providers.\n\nQuery Syntax Examples:\n- All S3 buckets: type:aws:s3:Bucket\n- Untagged resources: -properties.tags:*\n- Untagged S3 buckets: type:aws:s3:Bucket AND -properties.tags:*\n- Resources in production stack: stack:production\n- AWS Lambda functions: package:aws type:lambda:Function\n- Resources by project: project:my-app\n\nSupports field filters, boolean operators (AND, OR, NOT), exact matches with quotes, and property searches. The top parameter controls the maximum number of results to return (defaults to 20).',
+    schema: {
+      query: z
+        .string()
+        .describe(
+          'Lucene-style query to search for cloud resources. Examples: "type:aws:s3:Bucket AND -properties.tags:*" (untagged S3 buckets), "package:aws type:lambda:Function" (Lambda functions), "stack:production" (production resources)'
+        ),
+      org: z
+        .string()
+        .optional()
+        .describe('Pulumi organization name (optional, defaults to current default org)'),
+      top: z
+        .number()
+        .optional()
+        .describe('Maximum number of top results to return (defaults to 20)'),
+      size: z
+        .number()
+        .optional()
+        .describe('Number of results per page (defaults to 25)')
+    },
+    handler: async (args: ResourceSearchArgs) => {
+      const isTestMode = process.env.MCP_TEST_MODE === 'true';
+
+      if (isTestMode) {
+        // Get org - use provided org or mock default for testing
+        const org = args.org || 'mock-org';
+        
+        // Use mock client for testing
+        const mockClient = new MockPulumiApiClient();
+        const mockResponse = await mockClient.searchResources({
+          query: args.query,
+          org: org,
+          top: args.top
+        });
+
+        const results: ResourceSearchResult = {
+          query: args.query,
+          resources: mockResponse.resources,
+          summary:
+            mockResponse.totalResources > 0 && mockResponse.resources[0].name === 'acme-bucket'
+              ? 'Found 1 untagged S3 bucket: acme-bucket'
+              : `Found ${mockResponse.totalResources} resource${mockResponse.totalResources === 1 ? '' : 's'} matching your query`,
+          facets: mockResponse.facets,
+          totalResources: mockResponse.totalResources
+        };
+
+        return {
+          description: 'Pulumi resource search results',
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  query: results.query,
+                  org: org,
+                  results: {
+                    resources: results.resources,
+                    facets: results.facets,
+                    totalResources: results.totalResources
+                  },
+                  summary: results.summary
+                },
+                null,
+                2
+              )
+            }
+          ]
+        };
+      } else {
+        // Get org - use provided org or detect default org
+        const org = args.org || await getDefaultOrg();
+        
+        // Use real API client - will throw clear error if token is missing
+        const apiClient = createPulumiSearchApiClient();
+        const apiResponse = await apiClient.searchResources({
+          query: args.query,
+          org: org,
+          top: args.top,
+          size: args.size,
+          source: 'mcp-server'
+        });
+
+        const results: ResourceSearchResult = {
+          query: args.query,
+          resources: apiResponse.resources,
+          summary: `Found ${apiResponse.totalResources} resource${apiResponse.totalResources === 1 ? '' : 's'} matching your query`,
+          facets: apiResponse.facets,
+          totalResources: apiResponse.totalResources
+        };
+
+        return {
+          description: 'Pulumi resource search results',
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  query: results.query,
+                  org: org,
+                  results: {
+                    resources: results.resources,
+                    facets: results.facets,
+                    totalResources: results.totalResources
+                  },
+                  summary: results.summary
+                },
+                null,
+                2
+              )
+            }
+          ]
+        };
+      }
+    }
+  }
+};

--- a/src/insights/resource-search.ts
+++ b/src/insights/resource-search.ts
@@ -69,7 +69,10 @@ export const resourceSearchCommands = {
         .optional()
         .describe('Maximum number of top results to return (defaults to 20)'),
       size: z.number().optional().describe('Number of results per page (defaults to 25)'),
-      properties: z.boolean().optional().describe('Whether to include resource properties in the response (defaults to false)')
+      properties: z
+        .boolean()
+        .optional()
+        .describe('Whether to include resource properties in the response (defaults to false)')
     },
     handler: async (args: ResourceSearchArgs) => {
       const isTestMode = process.env.MCP_TEST_MODE === 'true';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8,6 +8,7 @@ import { cliCommands } from '../pulumi/cli.js';
 import { logger } from '../logging/logging.js';
 import { deployCommands, deployPrompts } from '../deploy/deploy.js';
 import { convertPrompts } from '../pulumi/convert.js';
+import { resourceSearchCommands } from '../insights/resource-search.js';
 
 // Get the directory of the current module
 const __filename = fileURLToPath(import.meta.url);
@@ -82,6 +83,19 @@ export class Server extends McpServer {
       this.tool(toolName, command.description, command.schema, async () => {
         try {
           return await command.handler();
+        } catch (error) {
+          return handleError(error, toolName);
+        }
+      });
+    });
+
+    // Register resource search commands
+    Object.entries(resourceSearchCommands).forEach(([commandName, command]) => {
+      const toolName = `pulumi-${commandName}`;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.tool(toolName, command.description, command.schema, async (args: any) => {
+        try {
+          return await command.handler(args);
         } catch (error) {
           return handleError(error, toolName);
         }

--- a/test/mcp-deploy-to-aws.test.ts
+++ b/test/mcp-deploy-to-aws.test.ts
@@ -3,16 +3,6 @@ import { expect } from 'chai';
 import { listTools, listPrompts, callTool } from './helpers.js';
 
 describe('MCP Tool: deploy-to-aws', function () {
-  before(async function () {
-    // Set test mode environment variable
-    process.env.MCP_TEST_MODE = 'true';
-  });
-
-  after(() => {
-    // Clean up test environment variable
-    delete process.env.MCP_TEST_MODE;
-  });
-
   describe('Tool Invocation', () => {
     it('should successfully invoke deploy-to-aws tool with no parameters', async function () {
       const response = await callTool('deploy-to-aws');

--- a/test/resource-search.test.ts
+++ b/test/resource-search.test.ts
@@ -1,0 +1,127 @@
+import { expect } from 'chai';
+import { testClaudeCodeInvocation, ClaudeCodeTest } from './helpers.js';
+import { resourceSearchCommands } from '../src/insights/resource-search.js';
+
+describe('Resource Search Tool', function () {
+  describe('Direct Tool Tests (Unit Tests)', () => {
+    const commands = resourceSearchCommands;
+
+    describe('Untagged S3 buckets query', () => {
+      it('should return acme-bucket for untagged S3 bucket query', async () => {
+        const args = {
+          query: 'type:aws:s3:Bucket AND -properties.tags:*'
+          // org will default to 'mock-org' in test mode
+        };
+
+        const result = await commands['resource-search'].handler(args);
+        const response = JSON.parse(result.content[0].text);
+
+        // Test that we get the expected resource
+        expect(response.results.resources).to.have.lengthOf(1);
+        expect(response.results.resources[0].name).to.equal('acme-bucket');
+      });
+    });
+
+    describe('Default query handling', () => {
+      it('should return default resource for non-S3 queries', async () => {
+        const args = {
+          query: 'package:aws type:lambda:Function'
+          // org will default to 'mock-org' in test mode
+        };
+
+        const result = await commands['resource-search'].handler(args);
+        const response = JSON.parse(result.content[0].text);
+
+        // Test that we get the default resource
+        expect(response.results.resources).to.have.lengthOf(1);
+        expect(response.results.resources[0].name).to.equal('example-resource');
+      });
+    });
+  });
+
+  describe('Claude Code SDK Integration Tests', function () {
+    before(function () {
+      if (!process.env.ANTHROPIC_API_KEY) {
+        console.log('Skipping Claude Code SDK tests - no API key');
+        this.skip();
+      }
+    });
+
+    describe('Natural Language to Resource Search Tool Selection', () => {
+      const resourceSearchTestCases: ClaudeCodeTest[] = [
+        {
+          query: 'Do I have any untagged S3 buckets?',
+          expectedTool: 'pulumi-resource-search',
+          description: 'Untagged S3 buckets query',
+          contextType: 'pulumi'
+        },
+        {
+          query: 'List all deployed Lambda functions in my AWS infrastructure',
+          expectedTool: 'pulumi-resource-search',
+          description: 'Lambda functions query',
+          contextType: 'pulumi'
+        },
+        {
+          query: 'Search for all EC2 instances in my production stack',
+          expectedTool: 'pulumi-resource-search',
+          description: 'Stack-based resource search query',
+          contextType: 'pulumi'
+        },
+        {
+          query: 'Find all my RDS database instances across all stacks',
+          expectedTool: 'pulumi-resource-search',
+          description: 'Resource type search query',
+          contextType: 'pulumi'
+        }
+      ];
+
+      resourceSearchTestCases.forEach((testCase) => {
+        it(`should invoke resource-search tool for: "${testCase.description}"`, async function () {
+          const toolInvoked = await testClaudeCodeInvocation(testCase);
+
+          // Verify the correct tool was invoked (Claude Code prefixes MCP tools with server name)
+          const expectedTools = [
+            'mcp__pulumi-mcp__pulumi-resource-search',
+            'mcp__pulumi-mcp-local__pulumi-resource-search'
+          ];
+          expect(expectedTools).to.include(
+            toolInvoked,
+            `Expected Claude Code to invoke resource-search tool with MCP prefix, but got: ${toolInvoked}`
+          );
+        });
+      });
+
+      // Test that it should NOT invoke resource search for non-resource queries
+      it('should NOT invoke resource-search for deployment queries', async function () {
+        const testCase: ClaudeCodeTest = {
+          query: 'Deploy this code to AWS',
+          expectedTool: 'should-not-invoke-resource-search',
+          description: 'AWS deployment request',
+          contextType: 'pulumi'
+        };
+
+        try {
+          const toolInvoked = await testClaudeCodeInvocation(testCase);
+
+          // Should NOT invoke resource search tools
+          const resourceSearchTools = [
+            'mcp__pulumi-mcp__pulumi-resource-search',
+            'mcp__pulumi-mcp-local__pulumi-resource-search'
+          ];
+          expect(resourceSearchTools).to.not.include(
+            toolInvoked,
+            `Claude incorrectly invoked resource-search for deployment query. Got: ${toolInvoked}`
+          );
+        } catch (error) {
+          // If no tool was invoked or a different tool was invoked, that's fine for this test
+          if (error instanceof Error && error.message.includes('No tool was invoked')) {
+            console.log('✅ Correct behavior: No tool invoked for deployment query');
+            return;
+          }
+          // For other errors, we still want to verify the tool name if it was invoked
+          throw error;
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Introduces a new Pulumi resource search tool.

Example:

```
> How many S3 buckets do I have in stack 'dev'?

⏺ pulumi-mcp-local - pulumi-resource-search (MCP)(query: "type:aws:s3:Bucket AND stack:dev")
  ⎿  {
       "query": "type:aws:s3:Bucket AND stack:dev",
       "org": "artur-1001-org",
     … +150 lines (ctrl+r to expand)

⏺ 1 S3 bucket in stack 'dev-hackathon' (the actual bucket resource is the BucketV2 type).
```