### PR TITLE
feat: resource search can ask for properties

### DIFF
--- a/src/insights/pulumi-api-client.ts
+++ b/src/insights/pulumi-api-client.ts
@@ -162,11 +162,11 @@ export class MockPulumiApiClient extends PulumiSearchApiClient {
             type: 'aws:s3:Bucket',
             project: 'example-project',
             stack: 'dev',
-            properties: {
+            properties: request.properties ? {
               bucket: 'acme-bucket',
               region: 'us-west-2'
               // No tags property = untagged
-            },
+            } : {},
             id: 'arn:aws:s3:::acme-bucket',
             created: '2024-01-15T10:30:00Z',
             modified: '2024-01-15T10:30:00Z',
@@ -192,10 +192,10 @@ export class MockPulumiApiClient extends PulumiSearchApiClient {
           type: 'aws:ec2:Instance',
           project: 'example-project',
           stack: 'dev',
-          properties: {
+          properties: request.properties ? {
             instanceType: 't3.micro',
             tags: { Environment: 'dev' }
-          },
+          } : {},
           id: 'i-1234567890abcdef0',
           created: '2024-01-15T10:30:00Z',
           modified: '2024-01-15T10:30:00Z',

--- a/src/insights/resource-search.ts
+++ b/src/insights/resource-search.ts
@@ -6,6 +6,7 @@ export type ResourceSearchArgs = {
   org?: string;
   top?: number;
   size?: number;
+  properties?: boolean;
 };
 
 export type ResourceSearchResult = {
@@ -67,7 +68,8 @@ export const resourceSearchCommands = {
         .number()
         .optional()
         .describe('Maximum number of top results to return (defaults to 20)'),
-      size: z.number().optional().describe('Number of results per page (defaults to 25)')
+      size: z.number().optional().describe('Number of results per page (defaults to 25)'),
+      properties: z.boolean().optional().describe('Whether to include resource properties in the response (defaults to false)')
     },
     handler: async (args: ResourceSearchArgs) => {
       const isTestMode = process.env.MCP_TEST_MODE === 'true';
@@ -81,7 +83,8 @@ export const resourceSearchCommands = {
         const mockResponse = await mockClient.searchResources({
           query: args.query,
           org: org,
-          top: args.top
+          top: args.top,
+          properties: args.properties
         });
 
         const results: ResourceSearchResult = {
@@ -128,6 +131,7 @@ export const resourceSearchCommands = {
           org: org,
           top: args.top,
           size: args.size,
+          properties: args.properties,
           source: 'mcp-server'
         });
 

--- a/test/resource-search.test.ts
+++ b/test/resource-search.test.ts
@@ -37,6 +37,53 @@ describe('Resource Search Tool', function () {
         expect(response.results.resources[0].name).to.equal('example-resource');
       });
     });
+
+    describe('Properties parameter handling', () => {
+      it('should pass properties parameter to the search request', async () => {
+        const args = {
+          query: 'type:aws:s3:Bucket -properties.tags:*',
+          properties: true
+        };
+
+        const result = await commands['resource-search'].handler(args);
+        const response = JSON.parse(result.content[0].text);
+
+        // Test that we get a resource with properties
+        expect(response.results.resources).to.have.lengthOf(1);
+        expect(response.results.resources[0]).to.have.property('properties');
+        expect(response.results.resources[0].properties).to.be.an('object');
+        expect(response.results.resources[0].properties['region']).to.equal('us-west-2');
+      });
+
+      it('should handle properties parameter set to false', async () => {
+        const args = {
+          query: 'type:aws:s3:Bucket -properties.tags:*',
+          properties: false
+        };
+
+        const result = await commands['resource-search'].handler(args);
+        const response = JSON.parse(result.content[0].text);
+
+        // Test that we still get a resource (properties behavior is handled by API)
+        expect(response.results.resources).to.have.lengthOf(1);
+        expect(response.results.resources[0]).to.have.property('properties');
+        expect(JSON.stringify(response.results.resources[0].properties)).to.equal('{}');
+      });
+
+      it('should work without properties parameter (defaults to false)', async () => {
+        const args = {
+          query: 'type:aws:s3:Bucket -properties.tags:*',
+        };
+
+        const result = await commands['resource-search'].handler(args);
+        const response = JSON.parse(result.content[0].text);
+
+        // Test that we get a resource without explicitly setting properties
+        expect(response.results.resources).to.have.lengthOf(1);
+        expect(response.results.resources[0]).to.have.property('properties');
+        expect(JSON.stringify(response.results.resources[0].properties)).to.equal('{}');
+      });
+    });
   });
 
   describe('Claude Code SDK Integration Tests', function () {


### PR DESCRIPTION
A small enhancement to resource search capability that seems useful for the application I am working on, "find aws lambda functions with a given nodejs runtime". Co-authored with Claude Code.

On top of: https://github.com/pulumi/mcp-server/pull/46