### PR TITLE
Fix ENOBUFS error in registry operations

### DIFF
--- a/scripts/test-direct.sh
+++ b/scripts/test-direct.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Test script to directly invoke MCP server tools via JSON-RPC 2.0
+# This bypasses MCP clients and allows seeing console.log output from the server
+# 
+# JSON-RPC 2.0 format:
+# - jsonrpc: "2.0" (protocol version)
+# - id: unique request identifier
+# - method: MCP method ("tools/call", "tools/list", etc.)
+# - params: method parameters (tool name and arguments)
+
+set -e
+
+# Get the absolute path of the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_SERVER="$SCRIPT_DIR/../dist/index.js"
+
+echo "Testing MCP server directly via JSON-RPC..."
+echo "Server: $MCP_SERVER"
+echo ""
+
+# Test pulumi-registry-get-resource tool with AWS S3 Bucket
+echo "Calling pulumi-registry-get-resource for AWS S3 Bucket..."
+echo ""
+
+# Send JSON-RPC request directly to MCP server
+echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "pulumi-registry-get-resource", "arguments": {"provider": "aws", "resource": "Bucket"}}}' | node "$MCP_SERVER" stdio
+
+echo ""
+echo "✅ Direct MCP test completed"


### PR DESCRIPTION
## Summary
- Fix ENOBUFS error when fetching large Pulumi provider schemas
- Increase maxBuffer from default 1MB to 50MB for `pulumi package get-schema`
- Add direct MCP testing script for debugging

## Problem
Registry operations were failing with "spawnSync pulumi ENOBUFS" error when fetching large provider schemas. The AWS provider schema is ~37MB, which exceeds Node.js default 1MB buffer limit for child processes.

## Solution
- Set explicit `maxBuffer: 50MB` in `execFileSync` call for schema operations
- Only applied where needed (registry operations), not for small outputs like org names
- Added comprehensive comments explaining the buffer requirement

## Test plan
- [x] Reproduced ENOBUFS error with large test output
- [x] Confirmed fix resolves the buffer overflow
- [x] Added `scripts/test-direct.sh` for direct JSON-RPC testing
- [x] Verified AWS provider schema operations work without errors

🤖 Generated with [Claude Code](https://claude.ai/code)