### PR TITLE
Added reference to the official image on the docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,19 @@ Or if you prefer HTTP with Server-Sent Events (SSE) instead of `stdio`:
 
 ## Docker Container
 
-You can also run the Pulumi MCP Server as a Docker container. This approach eliminates the need to install Node.js and the package dependencies directly on your host machine.
+You can also run the Pulumi MCP Server as a Docker container. This approach eliminates the need to install Node.js and the package dependencies directly on your host machine. The image may be pulled from the docker repository, or built on the device with all local changes included.
+
+### Using the Official Image
+
+To download the official Docker image from the repository:
+
+```bash
+docker pull mcp/pulumi:latest
+```
 
 ### Building the Container
 
-To build the container:
+To build the container locally:
 
 ```bash
 docker build -t pulumi/mcp-server:latest .
@@ -67,6 +75,19 @@ docker build -t pulumi/mcp-server:latest .
 ### Using with MCP Clients
 
 To use the containerized server with MCP clients, you'll need to configure the client to use the Docker container. For example, in Claude desktop's MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "pulumi": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/pulumi:latest", "stdio"]
+    }
+  }
+}
+```
+
+Or if using a locally built image:
 
 ```json
 {


### PR DESCRIPTION
README now informs the user about using either a locally built image, or pulling it from the docker registry.

Fixes #55 